### PR TITLE
MERGE - Ticket-12

### DIFF
--- a/backend/apps/user/interface/auth_views.py
+++ b/backend/apps/user/interface/auth_views.py
@@ -1,0 +1,32 @@
+# apps/user/interface/auth_views.py
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import AllowAny
+from rest_framework.throttling import ScopedRateThrottle
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Login with email and password",
+    description="Obtain JWT tokens using email and password.",
+    request=TokenObtainPairSerializer,
+    responses={200: TokenObtainPairSerializer},
+)
+class AuthLoginView(TokenObtainPairView):
+    permission_classes = (AllowAny,)
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "auth"
+
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Refresh access token",
+    request=TokenRefreshSerializer,
+    responses={200: TokenRefreshSerializer},
+)
+class AuthRefreshView(TokenRefreshView):
+    permission_classes = (AllowAny,)
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "auth"

--- a/backend/apps/user/tests.py
+++ b/backend/apps/user/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/apps/user/tests/test_auth_api.py
+++ b/backend/apps/user/tests/test_auth_api.py
@@ -1,0 +1,33 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ..models import Profile, User
+
+LOGIN = "/api/auth/login/"
+REFRESH = "/api/auth/refresh/"
+
+
+class TestAuthApi(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="john@example.com", password="password123")
+        Profile.objects.create(user=self.user)
+
+    def test_login_success_returns_tokens(self):
+        res = self.client.post(LOGIN, {"email": "john@example.com", "password": "password123"}, format="json")
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        assert "access" in body and "refresh" in body
+
+    def test_login_wrong_password_401(self):
+        res = self.client.post(LOGIN, {"email": "john@example.com", "password": "wrong!"}, format="json")
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_refresh_success_returns_new_access(self):
+        login = self.client.post(LOGIN, {"email": "john@example.com", "password": "password123"}, format="json").json()
+        res = self.client.post(REFRESH, {"refresh": login["refresh"]}, format="json")
+        assert res.status_code == status.HTTP_200_OK
+        assert "access" in res.json()
+
+    def test_refresh_invalid_token_401(self):
+        res = self.client.post(REFRESH, {"refresh": "not-a-token"}, format="json")
+        assert res.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_400_BAD_REQUEST)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -147,10 +147,12 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_CLASSES": [
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
+        "rest_framework.throttling.ScopedRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
         "user": "200/min",
         "anon": "30/min",
+        "auth": "10/min",  # Limite pour les endpoints d'authentification
     },
 }
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -5,6 +5,8 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from apps.user.interface.auth_views import AuthLoginView, AuthRefreshView
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     # OpenAPI schema & Swagger UI en public
@@ -20,6 +22,7 @@ urlpatterns = [
     ),
     # Votre API users
     path("api/user/", include("apps.user.urls", namespace="user")),
-    path("api/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    # Auth endpoints
+    path("api/auth/login/", AuthLoginView.as_view(), name="auth_login"),
+    path("api/auth/refresh/", AuthRefreshView.as_view(), name="auth_refresh"),
 ]


### PR DESCRIPTION
## Objet de la MR

Implémentation des endpoints d’authentification JWT permettant la connexion via email/mot de passe et le rafraîchissement de l’access token.

---

## Changements principaux

* **Ajout des endpoints Auth :**

  * `POST /api/auth/login` : connexion avec `email` et `password` → renvoie `access` + `refresh`.
  * `POST /api/auth/refresh` : régénération d’un `access` token valide à partir du `refresh`.

* **Création des vues dédiées :**

  * `AuthLoginView` (wrapper autour de `TokenObtainPairView`)
  * `AuthRefreshView` (wrapper autour de `TokenRefreshView`)

* **Documentation Swagger (drf-spectacular) :**

  * Tag **Auth** ajouté avec description.
  * Schémas d’entrée/sortie documentés pour les deux endpoints.
* **Throttling spécifique** :

  * Ajout d’une scope `auth` → limite de `10/min` pour limiter le brute-force.
* **Routing** :

  * Ajout des nouvelles routes dans `config/urls.py`.
* **Tests d’API** :

  * Login réussi → retourne `access` + `refresh`.
  * Login échec → 401.
  * Refresh réussi → retourne nouveau `access`.
  * Refresh invalide → 401/400.

---

## Fichiers créés / modifiés

* **Nouveau :**

  * `apps/user/interface/auth_views.py` → vues login/refresh.
  * `apps/user/tests/test_auth_api.py` → tests unitaires d’API.

* **Modifié :**

  * `config/urls.py` → ajout des routes `/api/auth/login` et `/api/auth/refresh`.
  * `settings.py` → ajout throttle scope `auth` dans `DEFAULT_THROTTLE_RATES`.
  * `SPECTACULAR_SETTINGS` → ajout du tag **Auth**.

---

## Résultat attendu

* Un utilisateur existant peut se connecter avec son email/mot de passe et recevoir un couple `access`/`refresh`.
* Un utilisateur peut renouveler son access token via son refresh token.
* Les appels sont correctement documentés dans Swagger et regroupés sous **Auth**.
* Les abus sont limités par un throttling dédié.

---

## Référence

https://www.notion.so/Ticket-12-BACK-Mettre-en-place-le-login-et-la-g-n-ration-de-tokens-24e449738dcc80e98e90f4430fb9f303?source=copy_link

---
