### PR TITLE
MERGE - Ticket-13

### DIFF
--- a/backend/apps/user/interface/auth_views.py
+++ b/backend/apps/user/interface/auth_views.py
@@ -1,10 +1,17 @@
 # apps/user/interface/auth_views.py
 
-from drf_spectacular.utils import extend_schema
-from rest_framework.permissions import AllowAny
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+from .serializers import LogoutSerializer
 
 
 @extend_schema(
@@ -30,3 +37,30 @@ class AuthRefreshView(TokenRefreshView):
     permission_classes = (AllowAny,)
     throttle_classes = (ScopedRateThrottle,)
     throttle_scope = "auth"
+
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Logout (invalidate refresh token)",
+    request=LogoutSerializer,
+    responses={
+        204: OpenApiResponse({"detail": "Logged out successfully"}),
+        400: OpenApiResponse({"refresh": ["Invalid token"]}),
+    },
+)
+class AuthLogoutView(APIView):
+    """Logout the user by invalidating the refresh token."""
+
+    permission_classes = (IsAuthenticated,)
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "auth"
+
+    def post(self, request):
+        ser = LogoutSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        try:
+            token = RefreshToken(ser.validated_data["refresh"])
+            token.blacklist()
+        except TokenError:
+            return Response({"refresh": ["Invalid token"]}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": "Logged out successfully"}, status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/user/interface/views.py
+++ b/backend/apps/user/interface/views.py
@@ -85,9 +85,3 @@ class UserViewSet(viewsets.ViewSet):
         user.set_password(ser.validated_data["new_password"])
         user.save()
         return Response({"detail": "Password changed successfully"}, status=204)
-        user = request.user
-        if not user.check_password(ser.validated_data["current_password"]):
-            return Response({"current_password": "Incorrect password"}, status=400)
-        user.set_password(ser.validated_data["new_password"])
-        user.save()
-        return Response({"detail": "Password changed successfully"}, status=204)

--- a/backend/apps/user/interface/views.py
+++ b/backend/apps/user/interface/views.py
@@ -41,12 +41,6 @@ from apps.user.services.user_service import UserService
         responses={204: OpenApiResponse({"detail": "Password changed successfully"})},
         tags=["Users"],
     ),
-    logout=extend_schema(
-        summary="Logout current user",
-        request=LogoutSerializer,
-        responses={204: OpenApiResponse({"detail": "Logged out successfully"})},
-        tags=["Auth"],
-    ),
 )
 class UserViewSet(viewsets.ViewSet):
     service = UserService(user_repository=UserRepository())
@@ -91,14 +85,9 @@ class UserViewSet(viewsets.ViewSet):
         user.set_password(ser.validated_data["new_password"])
         user.save()
         return Response({"detail": "Password changed successfully"}, status=204)
-
-    @action(detail=False, methods=["post"], url_path="logout", permission_classes=[IsAuthenticated])
-    def logout(self, request):
-        ser = LogoutSerializer(data=request.data)
-        ser.is_valid(raise_exception=True)
-        try:
-            token = RefreshToken(ser.validated_data["refresh"])
-            token.blacklist()
-        except Exception:
-            return Response({"refresh": ["Invalid token"]}, status=400)
-        return Response({"detail": "Logged out successfully"}, status=204)
+        user = request.user
+        if not user.check_password(ser.validated_data["current_password"]):
+            return Response({"current_password": "Incorrect password"}, status=400)
+        user.set_password(ser.validated_data["new_password"])
+        user.save()
+        return Response({"detail": "Password changed successfully"}, status=204)

--- a/backend/apps/user/tests/test_auth_logout.py
+++ b/backend/apps/user/tests/test_auth_logout.py
@@ -1,0 +1,33 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.user.models import Profile, User
+
+LOGIN = "/api/auth/login/"
+REFRESH = "/api/auth/refresh/"
+LOGOUT = "/api/auth/logout/"
+
+
+class TestAuthLogout(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="john@example.com", password="Secret123!")
+        Profile.objects.create(user=self.user)
+
+        login = self.client.post(LOGIN, {"email": "john@example.com", "password": "Secret123!"}, format="json").json()
+        self.access = login["access"]
+        self.refresh = login["refresh"]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.access}")
+
+    def test_logout_blacklists_refresh(self):
+        res = self.client.post(LOGOUT, {"refresh": self.refresh}, format="json")
+        print(res.status_code, res.content[:200])
+        assert res.status_code == status.HTTP_204_NO_CONTENT
+
+        # le même refresh ne doit plus être utilisable
+        res2 = self.client.post(REFRESH, {"refresh": self.refresh}, format="json")
+        assert res2.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_400_BAD_REQUEST)
+
+    def test_logout_with_invalid_token_returns_400(self):
+        res = self.client.post(LOGOUT, {"refresh": "not-a-token"}, format="json")
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "refresh" in res.json()

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -3,9 +3,8 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from apps.user.interface.auth_views import AuthLoginView, AuthRefreshView
+from apps.user.interface.auth_views import AuthLoginView, AuthLogoutView, AuthRefreshView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -25,4 +24,5 @@ urlpatterns = [
     # Auth endpoints
     path("api/auth/login/", AuthLoginView.as_view(), name="auth_login"),
     path("api/auth/refresh/", AuthRefreshView.as_view(), name="auth_refresh"),
+    path("api/auth/logout/", AuthLogoutView.as_view(), name="auth_logout"),
 ]


### PR DESCRIPTION
**Objet** : Ajout de l’endpoint `POST /api/auth/logout` avec invalidation du refresh token

**Modifications principales**

* Création de `AuthLogoutView` (APIView) dans `apps/user/interface/auth_views.py`

  * Reçoit un `refresh` token dans le body
  * Blackliste le token via `rest_framework_simplejwt.tokens.RefreshToken`
  * Retourne **204 No Content** si succès
  * Retourne **400 Bad Request** si le token est invalide ou déjà invalidé
* Ajout de la route `api/auth/logout` dans `config/urls.py` avec tag **Auth** et throttling scope `auth`
* Suppression de l’action `logout` dans `UserViewSet` pour éviter les doublons avec le nouvel endpoint
* Documentation OpenAPI/Swagger mise à jour via `drf_spectacular` (schéma de requête et réponses)
* Ajout de tests d’intégration :

  * Cas nominal : blacklist d’un refresh token valide et impossibilité de le réutiliser pour un refresh
  * Cas d’erreur : token invalide → 400

**Impact**

* Centralisation des endpoints d’authentification dans `/api/auth/*`
* Amélioration de la sécurité grâce à l’invalidation explicite des refresh tokens
* Suppression d’un endpoint redondant (`/api/user/logout`)
