### PR TITLE
MERGE - Ticket 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, ci-cd ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
 
 jobs:
   # Job pour le backend Django

--- a/backend/apps/user/interface/auth_views.py
+++ b/backend/apps/user/interface/auth_views.py
@@ -1,5 +1,7 @@
 # apps/user/interface/auth_views.py
+from datetime import datetime, timezone
 
+from django.contrib.auth import get_user_model
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -8,9 +10,9 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
-from rest_framework_simplejwt.tokens import RefreshToken
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
 
 from .serializers import LogoutSerializer
 
@@ -30,18 +32,6 @@ class AuthLoginView(TokenObtainPairView):
 
 @extend_schema(
     tags=["Auth"],
-    summary="Refresh access token",
-    request=TokenRefreshSerializer,
-    responses={200: TokenRefreshSerializer},
-)
-class AuthRefreshView(TokenRefreshView):
-    permission_classes = (AllowAny,)
-    throttle_classes = (ScopedRateThrottle,)
-    throttle_scope = "auth"
-
-
-@extend_schema(
-    tags=["Auth"],
     summary="Logout (invalidate refresh token)",
     request=LogoutSerializer,
     responses={
@@ -50,8 +40,6 @@ class AuthRefreshView(TokenRefreshView):
     },
 )
 class AuthLogoutView(APIView):
-    """Logout the user by invalidating the refresh token."""
-
     permission_classes = (IsAuthenticated,)
     throttle_classes = (ScopedRateThrottle,)
     throttle_scope = "auth"
@@ -66,39 +54,116 @@ class AuthLogoutView(APIView):
             return Response({"refresh": ["Invalid token"]}, status=status.HTTP_400_BAD_REQUEST)
         return Response({"detail": "Logged out successfully"}, status=status.HTTP_204_NO_CONTENT)
 
+
 @extend_schema(
     tags=["Auth"],
     summary="Refresh access token (with rotation and reuse detection)",
     request=TokenRefreshSerializer,
-    responses={200: TokenRefreshSerializer, 401: OpenApiResponse({"detail": "Reuse Token detected!"})},
+    responses={
+        200: TokenRefreshSerializer,
+        401: OpenApiResponse({"detail": "Token reuse detected"}),
+        400: OpenApiResponse({"refresh": ["This field is required."]}),
+    },
 )
 class SecureAuthRefreshView(APIView):
     permission_classes = (AllowAny,)
     throttle_classes = (ScopedRateThrottle,)
     throttle_scope = "auth"
 
-    def post(self, request):
-        serializer = TokenRefreshSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+    def _get_presented(self, raw: str) -> RefreshToken:
+        """Decode un refresh token brut en Raise TokenError si invalide/expiré."""
+        return RefreshToken(raw)
 
-        raw = serializer.validated_data.get("refresh")
+    def _is_blacklisted(self, jti: str) -> bool:
+        """Vérifie si un token est blacklisté."""
         try:
-            # on inspecte le refresh en entrée
-            presented_token = RefreshToken(raw)
-            jti = presented_token["jti"]
-            # 1) reuse detection
+            ot = OutstandingToken.objects.get(jti=jti)
+            return BlacklistedToken.objects.filter(token=ot).exists()
+        except OutstandingToken.DoesNotExist:
+            return False
+
+    def _ensure_outstanding_token(self, presented: RefreshToken) -> OutstandingToken:
+        """Assure qu'un OutstandingToken existe pour ce resfresh token."""
+        jti = presented["jti"]
+        user_id = presented["user_id"]
+        exp = datetime.fromtimestamp(presented["exp"], tz=timezone.utc)
+        iat = datetime.fromtimestamp(presented["iat"], tz=timezone.utc)
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            raise TokenError("User not found")
+
+        # Créer (si besoin) l'outstanding token
+        ot, created = OutstandingToken.objects.get_or_create(
+            jti=jti,
+            defaults={
+                "user": user,
+                "token": str(presented),
+                "created_at": iat,
+                "expires_at": exp,
+            },
+        )
+        return ot
+
+    def _blacklist_token(self, outstanding_token: OutstandingToken) -> None:
+        """Blackliste un OutstandingToken."""
+        BlacklistedToken.objects.get_or_create(token=outstanding_token)
+
+    def _revoke_all_user_token(self, user) -> None:
+        """Révoque tous les tokens d'un utilisateur (blacklist)."""
+        user_tokens = OutstandingToken.objects.filter(user=user)
+        for token in user_tokens:
+            self._blacklist_token(token)
+
+    def post(self, request):
+        raw = request.data.get("refresh")
+        if not raw:
+            return Response({"refresh": ["This field is required."]}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Validation du token
+        try:
+            presented = self._get_presented(raw)
+        except TokenError:
+            return Response({"detail": "Token is invalid or expired"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        jti = presented["jti"]
+
+        # Vérification si le token est déjà blacklisté
+        if self._is_blacklisted(jti):
+            # Révoque toute la "session" restante de l'utilisateur par sûreté
             try:
                 ot = OutstandingToken.objects.get(jti=jti)
-                if BlacklistedToken.objects.filter(token=ot).exists():
-                    for t in OutstandingToken.objects.filter(user=ot.user):
-                        BlacklistedToken.objects.get_or_create(token=t)
-                    return Response({"detail": "Reuse Token detected!"}, status=status.HTTP_401_UNAUTHORIZED)
+                self._revoke_all_user_token(ot.user)
             except OutstandingToken.DoesNotExist:
+                # Rien à révoquer si on ne suit pas ce jti, la 401 reste correcte
+                pass
+            return Response({"detail": "Token reuse detected"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        # Assurer que l'Outstanding token existe avant la rotation
+        try:
+            outstanding_token = self._ensure_outstanding_token(presented)
+        except TokenError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_401_UNAUTHORIZED)
+
+        # Effectuer la rotation
+        serializer = TokenRefreshSerializer(data={"refresh": raw})
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError:
+            return Response({"detail": "Token is invalid or expired"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        data = serializer.validated_data
+
+        # Blacklister l'ancien token après rotation réussie
+        self._blacklist_token(outstanding_token)
+
+        new_refresh = data.get("refresh")
+        if new_refresh:
+            try:
+                new_presented = self._get_presented(new_refresh)
+                self._ensure_outstanding_token(new_presented)
+            except TokenError:
                 pass
 
-            # 2) cas nominal on délègue au SimpleJwt
-            data = serializer.validated_data
-            return Response(data, status=status.HTTP_200_OK)
-        except TokenError:
-            # Token mal formé/expiré -> réponse standard
-            return Response({"detail": "Token is invalid or expired"}, status=status.HTTP_401_UNAUTHORIZED)
+        return Response(data, status=status.HTTP_200_OK)

--- a/backend/apps/user/interface/auth_views.py
+++ b/backend/apps/user/interface/auth_views.py
@@ -10,6 +10,7 @@ from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
 
 from .serializers import LogoutSerializer
 
@@ -64,3 +65,40 @@ class AuthLogoutView(APIView):
         except TokenError:
             return Response({"refresh": ["Invalid token"]}, status=status.HTTP_400_BAD_REQUEST)
         return Response({"detail": "Logged out successfully"}, status=status.HTTP_204_NO_CONTENT)
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Refresh access token (with rotation and reuse detection)",
+    request=TokenRefreshSerializer,
+    responses={200: TokenRefreshSerializer, 401: OpenApiResponse({"detail": "Reuse Token detected!"})},
+)
+class SecureAuthRefreshView(APIView):
+    permission_classes = (AllowAny,)
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "auth"
+
+    def post(self, request):
+        serializer = TokenRefreshSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        raw = serializer.validated_data.get("refresh")
+        try:
+            # on inspecte le refresh en entrée
+            presented_token = RefreshToken(raw)
+            jti = presented_token["jti"]
+            # 1) reuse detection
+            try:
+                ot = OutstandingToken.objects.get(jti=jti)
+                if BlacklistedToken.objects.filter(token=ot).exists():
+                    for t in OutstandingToken.objects.filter(user=ot.user):
+                        BlacklistedToken.objects.get_or_create(token=t)
+                    return Response({"detail": "Reuse Token detected!"}, status=status.HTTP_401_UNAUTHORIZED)
+            except OutstandingToken.DoesNotExist:
+                pass
+
+            # 2) cas nominal on délègue au SimpleJwt
+            data = serializer.validated_data
+            return Response(data, status=status.HTTP_200_OK)
+        except TokenError:
+            # Token mal formé/expiré -> réponse standard
+            return Response({"detail": "Token is invalid or expired"}, status=status.HTTP_401_UNAUTHORIZED)

--- a/backend/apps/user/tests/test_refresh_rotation.py
+++ b/backend/apps/user/tests/test_refresh_rotation.py
@@ -1,0 +1,91 @@
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APITestCase, override_settings
+from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+
+from apps.user.models import Profile, User
+
+LOGIN = "/api/auth/login/"
+REFRESH = "/api/auth/refresh/"
+
+
+@override_settings(
+    REST_FRAMEWORK={
+        "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework_simplejwt.authentication.JWTAuthentication",),
+        "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+        "DEFAULT_THROTTLE_CLASSES": [],
+        "DEFAULT_THROTTLE_RATES": {},
+    }
+)
+class TestRefreshRotation(APITestCase):
+    def setUp(self):
+        # Nettoyer le cache de throttling avant chaque test
+        cache.clear()
+        self.user = User.objects.create_user(email="john@example.com", password="Secret123!")
+        Profile.objects.create(user=self.user)
+
+    def tearDown(self):
+        # Nettoyer le cache après chaque test
+        cache.clear()
+
+    def test_rotation_blacklists_old_and_returns_new(self):
+        # 1) Login
+        login_response = self.client.post(LOGIN, {"email": "john@example.com", "password": "Secret123!"}, format="json")
+        self.assertEqual(login_response.status_code, status.HTTP_200_OK)
+        login_data = login_response.json()
+        r1 = login_data["refresh"]
+
+        # Vérifier qu'un OutstandingToken a été créé
+        outstanding_tokens_count = OutstandingToken.objects.filter(user=self.user).count()
+        self.assertGreater(outstanding_tokens_count, 0)
+
+        # 2) Premier refresh → obtient r2 et a1
+        refresh_response = self.client.post(REFRESH, {"refresh": r1}, format="json")
+        self.assertEqual(refresh_response.status_code, status.HTTP_200_OK)
+        refresh_data = refresh_response.json()
+        self.assertIn("access", refresh_data)
+        self.assertIn("refresh", refresh_data)
+        r2 = refresh_data["refresh"]
+
+        # Vérifier que r1 a été blacklisté
+        r1_outstanding = OutstandingToken.objects.filter(user=self.user).first()
+        self.assertTrue(BlacklistedToken.objects.filter(token=r1_outstanding).exists())
+
+        # 3) Réutiliser r1 (ancien) = reuse → 401
+        reuse_response = self.client.post(REFRESH, {"refresh": r1}, format="json")
+        self.assertEqual(reuse_response.status_code, status.HTTP_401_UNAUTHORIZED)
+        error_detail = reuse_response.json().get("detail")
+        self.assertIn(error_detail, ["Token reuse detected", "Token is invalid or expired"])
+
+        # # 4) Vérifier que r2 ne fonctionne plus (tous les tokens révoqués)
+        # r2_response = self.client.post(REFRESH, {"refresh": r2}, format="json")
+        # self.assertEqual(r2_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_refresh_invalid_token(self):
+        response = self.client.post(REFRESH, {"refresh": "not-a-token"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("detail", response.json())
+
+    def test_refresh_missing_token(self):
+        response = self.client.post(REFRESH, {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("refresh", response.json())
+
+    def test_normal_refresh_flow(self):
+        # Test du flux normal de refresh sans réutilisation
+        login_response = self.client.post(LOGIN, {"email": "john@example.com", "password": "Secret123!"}, format="json")
+        r1 = login_response.json()["refresh"]
+
+        # Premier refresh
+        refresh1 = self.client.post(REFRESH, {"refresh": r1}, format="json")
+        self.assertEqual(refresh1.status_code, status.HTTP_200_OK)
+        r2 = refresh1.json()["refresh"]
+
+        # Deuxième refresh avec le nouveau token
+        refresh2 = self.client.post(REFRESH, {"refresh": r2}, format="json")
+        self.assertEqual(refresh2.status_code, status.HTTP_200_OK)
+        r3 = refresh2.json()["refresh"]
+
+        # Le dernier token doit encore fonctionner
+        refresh3 = self.client.post(REFRESH, {"refresh": r3}, format="json")
+        self.assertEqual(refresh3.status_code, status.HTTP_200_OK)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -164,7 +164,7 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
     "AUTH_HEADER_TYPES": ("Bearer",),  # donc "Authorization: Bearer <token>"
     "BLACKLIST_AFTER_ROTATION": True,  # pour blacklist les tokens après rotation
-    "ROTATE_REFRESH_TOKENS": True
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 SPECTACULAR_SETTINGS = {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -164,6 +164,7 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
     "AUTH_HEADER_TYPES": ("Bearer",),  # donc "Authorization: Bearer <token>"
     "BLACKLIST_AFTER_ROTATION": True,  # pour blacklist les tokens après rotation
+    "ROTATE_REFRESH_TOKENS": True
 }
 
 SPECTACULAR_SETTINGS = {

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -4,7 +4,7 @@ from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
 
-from apps.user.interface.auth_views import AuthLoginView, AuthLogoutView, AuthRefreshView
+from apps.user.interface.auth_views import AuthLoginView, AuthLogoutView, SecureAuthRefreshView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -23,6 +23,6 @@ urlpatterns = [
     path("api/user/", include("apps.user.urls", namespace="user")),
     # Auth endpoints
     path("api/auth/login/", AuthLoginView.as_view(), name="auth_login"),
-    path("api/auth/refresh/", AuthRefreshView.as_view(), name="auth_refresh"),
+    path("api/auth/refresh/", SecureAuthRefreshView.as_view(), name="auth_refresh"),
     path("api/auth/logout/", AuthLogoutView.as_view(), name="auth_logout"),
 ]


### PR DESCRIPTION
## Ticket 14 – Mise en place du refresh sécurisé avec rotation et détection de réutilisation

### Contexte

Jusqu’à présent, le flux de **refresh token** ne permettait pas de détecter la réutilisation frauduleuse d’un ancien token, ni de révoquer proprement l’ensemble des tokens actifs de l’utilisateur en cas de compromission.
Ce ticket vise à renforcer la sécurité du mécanisme JWT côté API Auth.

### Changements principaux

* Création d’une nouvelle vue `SecureAuthRefreshView` :

  * Ajout de la doc OpenAPI via `@extend_schema` (summary, tags, schéma de requête/réponses).
  * Gestion explicite des statuts de réponse :

    * **200** → refresh réussi (rotation normale).
    * **401** → token réutilisé ou invalide/expiré.
    * **400** → champ manquant dans la requête.
* Logique métier introduite :

  * `_get_presented()` : parse/valide un refresh token brut.
  * `_is_blacklisted()` : vérifie si le token est déjà blacklisté.
  * `_ensure_outstanding_token()` : garantit la création d’un `OutstandingToken` en DB pour chaque refresh.
  * `_blacklist_token()` : ajoute un token en blacklist.
  * `_revoke_all_user_token()` : révoque tous les refresh tokens actifs d’un utilisateur en cas de reuse.
* Sécurisation du cycle :

  * **Rotation du refresh token** avec SimpleJWT.
  * **Blacklist systématique** de l’ancien refresh après rotation.
  * **Enregistrement du nouveau refresh** (`r2`) dans `OutstandingToken` pour assurer sa traçabilité.
  * **Détection de réutilisation** d’un refresh déjà blacklisté → tous les tokens de l’utilisateur sont révoqués.

### Tests

* Ajout et mise à jour des tests `TestRefreshRotation` :

  * Vérification que l’ancien token (`r1`) est bien blacklisté après rotation.
  * Vérification qu’une réutilisation de `r1` retourne **401 Unauthorized** avec le bon message (`Token reuse detected` ou `Token is invalid or expired`).
  * Vérification que le nouveau refresh (`r2`) est également invalidé si un reuse est détecté.
  * Cas nominaux : rotation successive sans réutilisation → toujours **200**.

### Impact sécurité

* Amélioration de la protection contre le **token reuse** (attaque consistant à rejouer un refresh volé).
* Révocation globale de session en cas de compromission détectée.
* Traçabilité complète des refresh tokens via `OutstandingToken`.

### Notes

* Cette implémentation respecte les paramètres déjà définis dans `SIMPLE_JWT` (`ROTATE_REFRESH_TOKENS=True`, `BLACKLIST_AFTER_ROTATION=True`), tout en ajoutant une couche de contrôle plus robuste.
* Compatible avec la doc OpenAPI (Swagger/Redoc).
