### PR TITLE
Ticket-24][BACK] — API catalog : list / retrieve (Areas & Prestations) + filtres, pagination, throttles, OpenAPI

### DIFF
--- a/backend/apps/catalog/interface/filters.py
+++ b/backend/apps/catalog/interface/filters.py
@@ -1,0 +1,27 @@
+import django_filters
+
+from apps.catalog.models import Prestation, PrestationStatus
+
+
+class PrestationFilter(django_filters.FilterSet):
+    area = django_filters.NumberFilter(field_name="area__id", lookup_expr="exact")
+    status = django_filters.CharFilter(method="filter_status")
+
+    def filter_status(self, queryset, name, value: str):
+        if not value:
+            return queryset
+        value = value.strip().upper()
+        # safe list of valid values:
+        try:
+            valid_values = [c.value for c in PrestationStatus]
+        except Exception:
+            # fallback: try using .values attribute if it exists
+            valid_values = getattr(PrestationStatus, "values", tuple())
+        if value in valid_values:
+            return queryset.filter(status=value)
+        # si statut invalide, retourner queryset vide ou ne rien filtrer selon ton choix :
+        return queryset.none()
+
+    class Meta:
+        model = Prestation
+        fields = ("area", "status")

--- a/backend/apps/catalog/interface/serializers.py
+++ b/backend/apps/catalog/interface/serializers.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+
+from apps.catalog.models import Area, Prestation
+
+
+class AreaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Area
+        fields = ["id", "name", "created_at", "updated_at"]
+
+
+class PrestationSerializer(serializers.ModelSerializer):
+    area = serializers.PrimaryKeyRelatedField(read_only=True)
+    area_name = serializers.CharField(source="area.name", read_only=True)
+    default_rate_eur = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Prestation
+        fields = [
+            "id",
+            "area",
+            "area_name",
+            "name",
+            "description",
+            "weight_days",
+            "default_rate_cents",
+            "default_rate_eur",
+            "status",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_default_rate_eur(self, obj):
+        return str(obj.default_rate_eur)

--- a/backend/apps/catalog/interface/urls.py
+++ b/backend/apps/catalog/interface/urls.py
@@ -1,0 +1,16 @@
+# apps/catalog/interface/urls.py
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import AreaViewSet, PrestationViewSet
+
+app_name = "catalog"
+
+router = DefaultRouter()
+# basename simples et prévisibles
+router.register(r"areas", AreaViewSet, basename="areas")
+router.register(r"prestations", PrestationViewSet, basename="prestations")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/backend/apps/catalog/interface/views.py
+++ b/backend/apps/catalog/interface/views.py
@@ -1,0 +1,74 @@
+import django_filters
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
+from rest_framework import filters as drf_filters
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.throttling import ScopedRateThrottle
+
+from apps.catalog.models import Area, Prestation
+from apps.core.permissions import IsAuthenticatedReadOnly
+
+from .filters import PrestationFilter
+from .serializers import AreaSerializer, PrestationSerializer
+
+
+class CatalogBaseViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """
+    ViewSet de base pour les catalogues.
+    """
+
+    permission_classes = [
+        IsAuthenticatedReadOnly,
+    ]  # read-only + auth
+    throttle_classes = [
+        ScopedRateThrottle,
+    ]
+    throttle_scope = "catalog"  # configuré dans settings
+
+
+@extend_schema(
+    tags=["Catalog"],
+    summary="Lister les domaines d'activité (areas)",
+    parameters=[
+        OpenApiParameter(name="search", description="Recherche par nom", required=False, type=str),
+    ],
+)
+class AreaViewSet(CatalogBaseViewSet):
+    """
+    ViewSet pour les domaines d'activité (areas).
+    """
+
+    queryset = Area.objects.all().order_by("name")
+    serializer_class = AreaSerializer
+    filter_backends = [drf_filters.SearchFilter, drf_filters.OrderingFilter]
+    search_fields = ["name"]
+    ordering_fields = ["name", "id"]
+    ordering = ["name"]
+
+
+@extend_schema(
+    tags=["Catalog"],
+    summary="Lister les prestations",
+    parameters=[
+        OpenApiParameter(name="area", description="Filtrer par id d'Area", required=False, type=int, many=True),
+        OpenApiParameter(name="status", description="Filtrer par statut (DRAFT, ACTIVE, ARCHIVED=", required=False, type=str),
+        OpenApiParameter(name="search", description="Recherche sur nom/description", required=False, type=str),
+        OpenApiParameter(
+            name="ordering", description="Tri: name,-name,area,status,weight_days,default_rate_cents", required=False, type=str
+        ),
+    ],
+)
+class PrestationViewSet(CatalogBaseViewSet):
+    """Viewset pour les prestations.
+
+    Args:
+        CatalogBaseViewSet (_type_): _description_
+    """
+
+    queryset = Prestation.objects.select_related("area").all().order_by("area__name", "name")
+    serializer_class = PrestationSerializer
+    filter_backends = [drf_filters.SearchFilter, drf_filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
+    filter_class = PrestationFilter
+    search_fields = ["name", "description"]
+    ordering_fields = ["name", "area", "status", "weight_days", "default_rate_cents", "id"]
+    ordering = ["area", "name"]

--- a/backend/apps/catalog/models.py
+++ b/backend/apps/catalog/models.py
@@ -63,7 +63,7 @@ class Prestation(TimestampedModel, SoftDeleteModel):
 
     # helpers côté code/business
     @property
-    def default_rate_euros(self) -> float:
+    def default_rate_eur(self) -> float:
         return cents_to_euros(self.default_rate_cents)
 
     def set_default_rate_eur(self, euros_decimal):

--- a/backend/apps/catalog/tests/test_api_catalog.py
+++ b/backend/apps/catalog/tests/test_api_catalog.py
@@ -1,0 +1,176 @@
+# apps/catalog/tests/test_api_catalog.py
+from urllib.parse import urlencode
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.catalog.models import Area, Prestation, PrestationStatus
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user(db):
+    u = User.objects.create_user(email="test@acme.io", password="pwd12345")
+    return u
+
+
+@pytest.fixture
+def seed_catalog(db):
+    a1 = Area.objects.create(name="Développement Web")
+    a2 = Area.objects.create(name="UI/UX Design")
+
+    p1 = Prestation.objects.create(
+        area=a1,
+        name="Site vitrine",
+        description="Simple site",
+        weight_days=5,
+        default_rate_cents=250000,
+        status=PrestationStatus.ACTIVE,
+    )
+    p2 = Prestation.objects.create(
+        area=a1,
+        name="Audit Django",
+        description="Perf & sécurité",
+        weight_days=2,
+        default_rate_cents=120000,
+        status=PrestationStatus.DRAFT,
+    )
+    p3 = Prestation.objects.create(
+        area=a2,
+        name="Maquettes 3 écrans",
+        description="Figma",
+        weight_days=3,
+        default_rate_cents=150000,
+        status=PrestationStatus.ACTIVE,
+    )
+    return {"areas": (a1, a2), "prestations": (p1, p2, p3)}
+
+
+# ---------- Helpers resilient to router naming ----------
+def _try_reverse(candidates):
+    """
+    Essaie plusieurs noms pour reverse() et retourne la première URL valide.
+    """
+    for name in candidates:
+        try:
+            return reverse(name)
+        except Exception:
+            continue
+    return None
+
+
+def get_areas_list_url():
+    # candidats possibles en fonction du basename qu'on a utilisé dans le router
+    candidates = [
+        "catalog:catalog-areas-list",
+        "catalog:catalog_areas-list",
+        "catalog:areas-list",
+        "catalog:areas-list",  # double entrée safe
+    ]
+    url = _try_reverse(candidates)
+    if url:
+        return url
+    # fallback direct path (prefix possible: /api/)
+    return "/api/catalog/areas/"
+
+
+def get_prestations_list_url():
+    candidates = [
+        "catalog:catalog-prestations-list",
+        "catalog:catalog_prestations-list",
+        "catalog:prestations-list",
+        "catalog:prestation-list",
+    ]
+    url = _try_reverse(candidates)
+    if url:
+        return url
+    return "/api/catalog/prestations/"
+
+
+def get_prestation_detail_url(pk):
+    candidates = [
+        "catalog:catalog-prestations-detail",
+        "catalog:catalog_prestations-detail",
+        "catalog:prestations-detail",
+        "catalog:prestation-detail",
+    ]
+    for name in candidates:
+        try:
+            return reverse(name, args=[pk])
+        except Exception:
+            continue
+    # fallback direct path
+    return f"/api/catalog/prestations/{pk}/"
+
+
+# ---------- tests ----------
+def test_areas_requires_auth(api_client):
+    url = get_areas_list_url()
+    resp = api_client.get(url)
+    assert resp.status_code in (401, 403)
+
+
+def test_prestations_requires_auth(api_client):
+    url = get_prestations_list_url()
+    resp = api_client.get(url)
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_list_areas_search(api_client, user, seed_catalog):
+    api_client.force_authenticate(user=user)
+    base = get_areas_list_url()
+    qs = urlencode({"search": "ui/ux"})
+    url = f"{base}?{qs}"
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    names = [x["name"] for x in resp.data["results"]]
+    assert any("UI/UX" in n for n in names)
+
+
+@pytest.mark.django_db
+def test_list_prestations_filter_by_area_and_status(api_client, user, seed_catalog):
+    api_client.force_authenticate(user=user)
+    a1 = seed_catalog["areas"][0]
+    base = get_prestations_list_url()
+    qs = urlencode({"area": a1.id, "status": "ACTIVE"})
+    url = f"{base}?{qs}"
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    results = resp.data["results"]
+    # On s'assure que les résultats sont bien des prestations (champs attendus)
+    assert all("name" in r and "default_rate_cents" in r for r in results)
+    # On vérifie qu'au moins la prestation 'Site vitrine' est présente
+    assert any(r["name"] == "Site vitrine" for r in results)
+
+
+@pytest.mark.django_db
+def test_list_prestations_ordering(api_client, user, seed_catalog):
+    api_client.force_authenticate(user=user)
+    base = get_prestations_list_url()
+    qs = urlencode({"ordering": "-default_rate_cents"})
+    url = f"{base}?{qs}"
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    values = [x["default_rate_cents"] for x in resp.data["results"]]
+    assert values == sorted(values, reverse=True)
+
+
+@pytest.mark.django_db
+def test_retrieve_prestation(api_client, user, seed_catalog):
+    api_client.force_authenticate(user=user)
+    p = seed_catalog["prestations"][0]
+    url = get_prestation_detail_url(p.id)
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    assert resp.data["id"] == p.id
+    assert resp.data["area"] == p.area_id
+    assert resp.data["area_name"] == p.area.name

--- a/backend/apps/core/permissions.py
+++ b/backend/apps/core/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsAuthenticatedReadOnly(BasePermission):
+    """
+    Autorise uniquement les requêtes SAFE (GET/HEAD/OPTIONS) pour les users authentifiés.
+    """
+
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and request.method in SAFE_METHODS

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -155,7 +155,15 @@ REST_FRAMEWORK = {
         "user": "200/min",
         "anon": "30/min",
         "auth": "10/min",  # Limite pour les endpoints d'authentification
+        "catalog": "60/min",
     },
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 20,
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework.filters.SearchFilter",
+        "rest_framework.filters.OrderingFilter",
+    ],
 }
 
 # Optionnel: personnalisation des headers JWT
@@ -176,7 +184,10 @@ SPECTACULAR_SETTINGS = {
     "TAGS": [
         {"name": "Auth", "description": "JWT Authentication & session endpoints"},
         {"name": "Users", "description": "User & profile management"},
+        {"name": "Catalog", "description": "Areas & Prestations"},
     ],
+    "SERVE_INCLUDE_SCHEMA": False,  # include schema endpoint into schema
+    "COMPONENT_SPLIT_REQUEST": True,
 }
 
 # Models

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -25,4 +25,6 @@ urlpatterns = [
     path("api/auth/login/", AuthLoginView.as_view(), name="auth_login"),
     path("api/auth/refresh/", SecureAuthRefreshView.as_view(), name="auth_refresh"),
     path("api/auth/logout/", AuthLogoutView.as_view(), name="auth_logout"),
+    # Catalog
+    path("api/catalog/", include("apps.catalog.interface.urls", namespace="catalog")),
 ]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Résumé

Ajout d’une API REST read-only pour le catalogue métier afin d’exposer :

* la liste et le détail des **Areas** (`GET /api/catalog/areas/`, `GET /api/catalog/areas/{id}/`) ;
* la liste et le détail des **Prestations** (`GET /api/catalog/prestations/`, `GET /api/catalog/prestations/{id}/`) ;

Fonctionnalités incluses :

* recherche (`?search=` sur name/description), filtres (`?area=&status=`), tri/ordering, pagination ;
* permissions : accès **lecture** uniquement pour utilisateurs authentifiés ;
* throttling scoped (`catalog`) pour protéger l’endpoint public ;
* documentation OpenAPI (drf-spectacular) + annotations `@extend_schema` ;
* tests pytest / pytest-django pour couvrir list, retrieve, filtres, ordering et permissions.

## Détails techniques / fichiers ajoutés

### Nouveaux fichiers (structure)

* `apps/catalog/interface/serializers.py` — `AreaSerializer`, `PrestationSerializer`
* `apps/catalog/interface/views.py` — `AreaViewSet`, `PrestationViewSet` (List + Retrieve, SearchFilter, OrderingFilter, DjangoFilterBackend)
* `apps/catalog/interface/filters.py` — `PrestationFilter` (`area`, `status`)
* `apps/catalog/interface/urls.py` — router DRF (basenames `areas` / `prestations`)
* `apps/catalog/interface/tests/test_api_catalog.py` — tests API (auth required, list/search/filter/order/retrieve)
* (réutilise) `apps/core/permissions.py` — `IsAuthenticatedReadOnly` (read-only pour users authentifiés)

### Changements settings

* `REST_FRAMEWORK` (si non présent) :

  * `DEFAULT_PAGINATION_CLASS`: `PageNumberPagination`, `PAGE_SIZE: 20`
  * `DEFAULT_FILTER_BACKENDS`: `DjangoFilterBackend`, `SearchFilter`, `OrderingFilter`
  * `DEFAULT_THROTTLE_CLASSES`: `ScopedRateThrottle`
  * `DEFAULT_THROTTLE_RATES`: e.g. `"catalog": "60/min"`
  * `DEFAULT_SCHEMA_CLASS`: `drf_spectacular.openapi.AutoSchema`
* `SPECTACULAR_SETTINGS` : titre/version minimal + serve swagger (déjà en place)

### OpenAPI

* `@extend_schema` sur viewsets pour fournir descriptions, paramètres (`area`, `status`, `search`, `ordering`) et exemples.
* Routes publiques : `/api/schema/`, `/api/docs/` (Swagger) — conservées.

## Tests & QA

* Tests ajoutés couvrant :

  * accès non authentifié (401/403),
  * list/search d’Areas,
  * list/filter (`area`, `status`) & ordering pour Prestations,
  * retrieve Prestations (détail) ;

* Commandes utiles :

  ```bash
  pytest apps/catalog/tests/test_api_catalog.py -q
  pytest --cov=apps.catalog --cov-report=term-missing
  ```

* Vérifications manuelles :

  * Lancer serveur et tester `/api/catalog/areas/` et `/api/catalog/prestations/` via Swagger UI `/api/docs/` ;
  * Vérifier throttling en effectuant >60 requêtes/min (test de dev) ;
  * Tester auth JWT (ou méthode d’auth utilisée par le projet).

## QA steps (rapide)

1. `pip install -r requirements-dev.txt` (vérifier `django-filter`, `drf-spectacular`, `pytest-django`)
2. `pytest apps/catalog/tests/test_api_catalog.py` — tous doivent passer
3. `python manage.py runserver` → ouvrir `/api/docs/` → tester endpoints (authentifier un user)
4. Vérifier ordering & filtres via requêtes curl ou Swagger

## Impacts / Rollback

* **Impacts** :

  * Ajout d’URLs API (`/api/catalog/...`) et nouvelles vues sérialisées ;
  * Modifs possibles dans `REST_FRAMEWORK` settings (ajout de throttles, filter backends).

* **Rollback** :

  * Revert de la MR : suppression des fichiers ajoutés + restauration des settings modifiés.

## Notes produit

* L’API expose les données du catalogue en lecture seule ; l’écriture (création/édition/suppression) et l’affectation d’areas à des users sont hors-scope et feront l’objet de tickets séparés (ex : endpoints d’assignation, endpoints pour gestion par admin/owner).
* Modèle métier prévu : possibilité d’utiliser `prestation.default_rate_cents` pour forfait, ou `prestation.weight_days * tjm_freelance` pour facturation au temps → l’API expose ces champs pour permettre cette logique côté service de devis.

