### PR TITLE
MERGE - feat(quote): enforce owner/admin access control for Quote endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,31 @@ jobs:
 
       - name: Lint with ESLint
         run: pnpm run lint
+      - name: Prettier & env debug (CI debug)
+        run: |
+          echo "== node/pnpm/prettier versions =="
+          node -v
+          pnpm -v
+          pnpm exec -- prettier --version
 
+          echo "== git ls-files (top) =="
+          git ls-files | sed -n '1,60p'
+
+          echo "== Prettier list-different (files) =="
+          pnpm exec -- prettier --list-different src/interface/pages/QuoteCreatePage.tsx || true
+
+          echo "== Running prettier --write (temporary) to show diff =="
+          pnpm exec -- prettier --write src/interface/pages/QuoteCreatePage.tsx || true
+
+          echo "== Git diff after prettier --write =="
+          git --no-pager diff -- src/interface/pages/QuoteCreatePage.tsx || true
+
+          # optional: show file head & line endings
+          echo "== File head (visible) =="
+          sed -n '1,120p' src/interface/pages/QuoteCreatePage.tsx || true
+
+          echo "== show last 3 bytes (EOL check) =="
+          hexdump -C -n 64 src/interface/pages/QuoteCreatePage.tsx | sed -n '1,10p' || true
       - name: Check formatting with Prettier
         run: pnpm run format:check
 

--- a/backend/apps/quote/interface/views.py
+++ b/backend/apps/quote/interface/views.py
@@ -42,7 +42,7 @@ except Exception:
 
 # Small serializer to document change_status payload in the schema
 class ChangeStatusSerializer(serializers.Serializer):
-    status = serializers.ChoiceField(choices=[c.value for c in Quote.Status])
+    status = serializers.ChoiceField(choices=Quote.Status.choices)
 
 
 # Pagination class
@@ -125,20 +125,20 @@ class QuoteViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         """
-        Base queryset used for list operations and normal lookups.
-        - Regular users see only their own quotes.
-        - Staff/superuser see all quotes.
-        - Unauthenticated users see none.
+        Owners see their quotes. Staff/superuser can see all if they pass ?all=true.
+        Unauthenticated users get empty queryset.
         """
         qs = super().get_queryset()
         user = getattr(self.request, "user", None)
-
         if not user or not user.is_authenticated:
             return qs.none()
-
+        # staff may optionally request everything with ?all=true
         if user.is_staff or user.is_superuser:
-            return qs
-
+            all_param = self.request.query_params.get("all", "").lower()
+            if all_param in ("1", "true", "yes"):
+                return qs
+            # default for staff: limit to their own quotes (safer), unless ?all=true
+            return qs.filter(owner=user)
         return qs.filter(owner=user)
 
     # ----------------------
@@ -220,7 +220,14 @@ class QuoteViewSet(viewsets.ModelViewSet):
         quote = self._get_detail_obj(pk)
         # perform object-level permission check (will raise 403 if not allowed)
         self.check_object_permissions(request, quote)
-
+        # --- Defensive check: ensure only the owner can send the quote ---
+        # This is redundant if the permission class already enforces it,
+        # but provides a clearer error message and explicit guard.
+        if getattr(quote, "owner", None) != getattr(request, "user", None):
+            return Response(
+                {"detail": "Only the owner of the quote is allowed to send it."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         quote.status = Quote.Status.SENT
         quote.sent_at = timezone.now()
         quote.save(update_fields=["status", "sent_at", "updated_at"])
@@ -269,7 +276,7 @@ class QuoteViewSet(viewsets.ModelViewSet):
 
         owner = request.user
         cloned_fields = {
-            "owner": owner,
+            "owner": original.owner,  # keep same owner
             "client": original.client,
             "title": f"{original.title} (copy)",
             "reference": _generate_reference_for_owner(owner),


### PR DESCRIPTION
## feat(quote): enforce owner/admin access control for Quote endpoints (Ticket-40)

- Add IsOwnerOrAdmin permission class to require authentication and restrict object-level actions: only the quote owner may call send, while owner or admin (staff/superuser) can retrieve/update/delete (apps/quote/interface/permissions.py)
- Apply permission checks to QuoteViewSet and scope list lookups: get_queryset() now returns only the requesting user’s quotes for regular users. Staff/superuser may request all quotes explicitly with ?all=true.
- Detail lookup helper (_get_detail_obj) + get_object() ensure consistent scoped lookups while allowing admins an unrestricted fallback when appropriate.
- send action remains owner-only and includes an explicit defensive check to return a clear 403 when invoked by non-owners. (apps/quote/interface/views.py)
- Admin UX: keep destroy mapped to soft-cancel (status -> CANCELLED) and create matching QuoteHistory entries for audit.
- Add/adjust tests to cover the security rules: other professionals cannot view/edit/send another owner’s quote admin can view/cancel other owners’ quotes when using ?all=true (apps/quote/tests/test_permissions.py)