### PR TITLE
fix(auth): allow staff to edit role and block admin self-signup

### DIFF
--- a/backend/apps/user/interface/serializers.py
+++ b/backend/apps/user/interface/serializers.py
@@ -11,7 +11,7 @@ from apps.user.models.models import ProfessionalUser
 
 from ..models import Profile, User
 
-logger = logging.getLogger("apps.user.serializers")
+logger = logging.getLogger("apps.user")
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -24,9 +24,21 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
         fields = ["first_name", "last_name", "birthday", "phone", "avatar_url", "role"]
-        extra_kwargs = {
-            "role": {"required": False},
-        }
+        extra_kwargs = {"role": {"required": False}}
+
+    def get_fields(self):
+        fields = super().get_fields()
+        request = self.context.get("request")
+        # Si pas staff: role non éditable
+        if not (request and getattr(request.user, "is_staff", False)):
+            fields["role"].read_only = True
+        return fields
+
+    def validate_role(self, value):
+        request = self.context.get("request")
+        if value == Profile.Role.ADMIN and not (request and request.user.is_staff):
+            raise ValidationError("Only staff can assign admin role.")
+        return value
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -52,6 +64,35 @@ class UserRegistrationSerializer(serializers.Serializer):
         cleaned = v.strip().lower()
         logger.debug("UserRegistrationSerializer.validate_email -> %s", cleaned)
         return cleaned
+
+    def validate(self, attrs):
+        # Si un role 'admin' arrive, on l'ignore ou lève une erreur
+        prof = attrs.get("profile") or {}
+        if prof.get("role") == Profile.Role.ADMIN:
+            prof["role"] = Profile.Role.FREELANCE
+            attrs["profile"] = prof
+            logger.warning("UserRegistration: attempt to self-register as admin -> forcing role=freelance")
+        return attrs
+
+    def create(self, validated_data):
+        profile_data = validated_data.pop("profile", {}) or {}
+        # Créer l'utilisateur
+        user = User.objects.create_user(
+            email=validated_data["email"],
+            password=validated_data["password"],
+            **validated_data,
+        )
+        # Créer le profil
+        Profile.objects.create(
+            user=user,
+            first_name=profile_data.get("first_name") or "",
+            last_name=profile_data.get("last_name") or "",
+            birthday=profile_data.get("birthday") or "",
+            phone=profile_data.get("phone") or "",
+            avatar_url=profile_data.get("avatar_url") or "",
+            role=profile_data.get("role") or Profile.Role.FREELANCE,
+        )
+        return user
 
 
 class ChangePasswordSerializer(serializers.Serializer):

--- a/backend/apps/user/interface/views.py
+++ b/backend/apps/user/interface/views.py
@@ -104,7 +104,7 @@ class UserViewSet(viewsets.ViewSet):
         else:
             payload = data
 
-        ser = ProfileUpdateSerializer(user.profile, data=payload, partial=True)
+        ser = ProfileUpdateSerializer(user.profile, data=payload, partial=True, context={"request": request})
         ser.is_valid(raise_exception=True)
         ser.save()
 
@@ -115,7 +115,7 @@ class UserViewSet(viewsets.ViewSet):
     @extend_schema(request=ProfileUpdateSerializer, responses=UserSerializer, summary="Update profile of current user")
     def update_me_profile(self, request):
         logger.info("users.update_me_profile called", extra={"user_id": request.user.id, "params": request.data})
-        ser = ProfileUpdateSerializer(request.user.profile, data=request.data, partial=True)
+        ser = ProfileUpdateSerializer(request.user.profile, data=request.data, partial=True, context={"request": request})
         try:
             ser.is_valid(raise_exception=True)
             ser.save()

--- a/backend/apps/user/tests/test_user_api.py
+++ b/backend/apps/user/tests/test_user_api.py
@@ -19,9 +19,8 @@ ME_PROFILE = "/api/user/me/profile/"
 )
 class UserApiTests(APITestCase):
     def setUp(self):
-        # user "classique" pour les tests /me
+        # user "classique" pour tests /me
         self.user = User.objects.create_user(email="john@example.com", password="Secret123!")
-        # Comme on n'a pas de signal post_save, on crée le Profile explicitement si besoin
         if not hasattr(self.user, "profile"):
             Profile.objects.create(user=self.user, first_name="John", last_name="Doe")
 
@@ -50,9 +49,16 @@ class UserApiTests(APITestCase):
         self.assertIn("profile", body)
         self.assertEqual(body["profile"]["first_name"], "Jeanne")
         self.assertEqual(body["profile"]["last_name"], "Dupont")
+        # rôle créé par défaut/forcé côté back
+        self.assertEqual(body["profile"]["role"], "freelance")
 
     def test_register_user_legacy_full_name_phone(self):
-        payload = {"email": "legacy@example.com", "password": "Secret123!", "full_name": "Marie Curie", "phone": "0600000000"}
+        payload = {
+            "email": "legacy@example.com",
+            "password": "Secret123!",
+            "full_name": "Marie Curie",
+            "phone": "0600000000",
+        }
         res = self.client.post(BASE, data=payload, format="json")
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
         body = res.json()
@@ -60,6 +66,39 @@ class UserApiTests(APITestCase):
         self.assertEqual(body["profile"]["first_name"], "Marie")
         self.assertEqual(body["profile"]["last_name"], "Curie")
         self.assertEqual(body["profile"]["phone"], "0600000000")
+        self.assertEqual(body["profile"]["role"], "freelance")
+
+    def test_register_defaults_to_freelance_when_role_missing(self):
+        payload = {
+            "email": "no_role@example.com",
+            "password": "Secret123!",
+            "profile": {"first_name": "Nora", "last_name": "Ole"},
+        }
+        res = self.client.post(BASE, data=payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(res.json()["profile"]["role"], "freelance")
+
+    def test_register_attempt_admin_forced_to_freelance_and_logs_warning(self):
+        payload = {
+            "email": "wannabe.admin@example.com",
+            "password": "Secret123!",
+            "profile": {"first_name": "Wanna", "last_name": "Admin", "role": "admin"},
+        }
+        # capture le warning logger si tu as laissé un logger.warning côté serializer
+        with self.assertLogs("apps.user", level="WARNING") as cm:
+            res = self.client.post(BASE, data=payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        body = res.json()
+        self.assertEqual(body["profile"]["role"], "freelance")
+        # optionnel : assert qu'on a bien loggé quelque chose
+        joined = "\n".join(cm.output)
+        self.assertIn("self-register as admin", joined)
+
+    def test_register_duplicate_email_returns_400(self):
+        payload = {"email": "john@example.com", "password": "Secret123!"}
+        res = self.client.post(BASE, data=payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", res.json())
 
     # ---------- /me ----------
 
@@ -78,19 +117,52 @@ class UserApiTests(APITestCase):
 
     # ---------- PATCH /me/profile ----------
 
-    def test_update_profile(self):
+    def test_update_profile_basic_fields(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.token}")
         patch = {"first_name": "Johnny", "avatar_url": "https://cdn.test/john.png"}
         res = self.client.patch(ME_PROFILE, data=patch, format="json")
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         body = res.json()
-        # On a choisi de renvoyer UserSerializer, donc profil inclus
+        # on renvoie UserSerializer (avec profil)
         self.assertEqual(body["profile"]["first_name"], "Johnny")
         self.assertTrue(body["profile"]["avatar_url"].endswith("john.png"))
+        # rôle resté freelance
+        self.assertEqual(body["profile"]["role"], "freelance")
 
-    def test_register_duplicate_email_returns_400(self):
-        payload = {"email": "john@example.com", "password": "Secret123!"}
-        # user initial créé en setUp()
-        res = self.client.post("/api/user/", data=payload, format="json")
-        assert res.status_code == status.HTTP_400_BAD_REQUEST
-        assert "email" in res.json()
+    def test_non_staff_cannot_promote_self_to_admin_role_is_ignored(self):
+        """
+        Avec ProfileUpdateSerializer.get_fields() qui met role en read_only pour non-staff,
+        le champ est ignoré et le rôle reste 'freelance'.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.token}")
+        res1 = self.client.get(ME)
+        self.assertEqual(res1.status_code, status.HTTP_200_OK)
+        self.assertEqual(res1.json()["profile"]["role"], "freelance")
+
+        # tentative de promotion
+        res = self.client.patch(ME_PROFILE, data={"role": "admin"}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        body = res.json()
+        self.assertEqual(body["profile"]["role"], "freelance")
+
+    def test_staff_can_set_admin_role_on_self(self):
+        """
+        Si tu autorises les staff à modifier leur propre rôle via /me/profile/,
+        ce test vérifie que ça passe à 'admin'.
+        """
+        staff = User.objects.create_user(email="staff@example.com", password="Secret123!", is_staff=True)
+        if not hasattr(staff, "profile"):
+            Profile.objects.create(user=staff, first_name="Staff", last_name="User")
+        staff_token = str(AccessToken.for_user(staff))
+
+        # sanity check
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {staff_token}")
+        res0 = self.client.get(ME)
+        self.assertEqual(res0.status_code, status.HTTP_200_OK)
+        self.assertEqual(res0.json()["profile"]["role"], "freelance")
+
+        # promotion -> admin
+        res = self.client.patch(ME_PROFILE, data={"role": "admin"}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        body = res.json()
+        self.assertEqual(body["profile"]["role"], "admin")

--- a/frontend/src/interface/components/register/RegisterForm.tsx
+++ b/frontend/src/interface/components/register/RegisterForm.tsx
@@ -24,7 +24,7 @@ const schema = z.object({
       .string()
       .optional()
       .refine((v) => !v || /^https?:\/\//.test(v), "URL d'avatar invalide"),
-    role: z.enum(['freelance', 'client', 'admin']),
+    role: z.literal('freelance'),
   }),
 });
 
@@ -263,39 +263,6 @@ export default function RegisterForm() {
               Tu pourras importer un fichier plus tard (upload côté app).
             </p>
           </div>
-        </div>
-
-        {/* Rôle : radios segmentées */}
-        <div className={styles.roleGroup}>
-          <span className={styles.label}>Rôle</span>
-          <div className={styles.segmented}>
-            <label className={styles.segment}>
-              <input
-                type="radio"
-                value="freelance"
-                {...register('profile.role')}
-                defaultChecked
-              />
-              <span>Freelance</span>
-            </label>
-            <label className={styles.segment}>
-              <input
-                type="radio"
-                value="client"
-                {...register('profile.role')}
-              />
-              <span>Client</span>
-            </label>
-            <label className={styles.segment}>
-              <input type="radio" value="admin" {...register('profile.role')} />
-              <span>Admin</span>
-            </label>
-          </div>
-          {errors.profile?.role && (
-            <small className={styles.error}>
-              {errors.profile.role.message}
-            </small>
-          )}
         </div>
       </section>
 


### PR DESCRIPTION
- backend: User registration now forces role=freelance and logs attempt to self-register as admin
- backend: ProfileUpdateSerializer now correctly receives request context (role editable for staff)
- backend: PATCH /api/user/me and /api/user/me/profile now pass context={"request": request}
- tests: updated UserApiTests to assert staff can set admin role and log capture for self-register
- frontend: RegisterForm cleaned up to remove admin/client role options and default to freelance