### PR TITLE
Merge Request — feat/generate-pdf

### DIFF
--- a/backend/apps/quote/interface/renderers.py
+++ b/backend/apps/quote/interface/renderers.py
@@ -1,11 +1,25 @@
+# apps/quote/interface/renderers.py
+from django.utils.encoding import force_bytes
 from rest_framework.renderers import BaseRenderer
 
 
 class PDFRenderer(BaseRenderer):
     media_type = "application/pdf"
     format = "pdf"
-    charset = None
-    render_style = "binary"
+    charset = None  # très important: binaire
+    render_style = "binary"  # indique à DRF que c'est du binaire
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        return data
+        # Cas classiques
+        if data is None:
+            return b""
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            return bytes(data)
+        if isinstance(data, str):
+            return data.encode("utf-8")
+
+        # Fallback robuste (erreurs DRF, dicts, etc.)
+        try:
+            return force_bytes(data)
+        except Exception:
+            return force_bytes(str(data))

--- a/backend/apps/quote/interface/urls.py
+++ b/backend/apps/quote/interface/urls.py
@@ -1,5 +1,5 @@
 # apps/quote/interface/urls.py
-from django.urls import path
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import QuotePreviewPdfView, QuoteViewSet
@@ -12,4 +12,5 @@ urlpatterns = [
     # endpoint pour la prévisualisation PDF
     path("preview-pdf/", QuotePreviewPdfView.as_view(), name="quote_preview_pdf"),
     # routes par défaut
+    path("", include(router.urls)),
 ] + router.urls

--- a/backend/apps/quote/interface/views.py
+++ b/backend/apps/quote/interface/views.py
@@ -35,7 +35,14 @@ from apps.quote.interface.serializers import (
     QuoteSerializer,
 )
 from apps.quote.models import Quote, QuoteHistory, QuoteLineItem
-from apps.quote.services.pdf_preview import QuotePreviewContext, render_quote_pdf
+from apps.quote.services.pdf_generator import (
+    QuotePdfError,
+)
+from apps.quote.services.pdf_generator import render_quote_pdf as render_quote_document_pdf
+from apps.quote.services.pdf_preview import (
+    QuotePreviewContext,
+)
+from apps.quote.services.pdf_preview import render_quote_pdf as render_quote_preview_pdf
 
 logger = logging.getLogger(__name__)
 
@@ -461,6 +468,19 @@ class QuoteViewSet(viewsets.ModelViewSet):
         logger.info("quote.update.response", extra={"status": 200})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @action(detail=True, methods=["get"], url_path="pdf", renderer_classes=[PDFRenderer, JSONRenderer, BrowsableAPIRenderer])
+    def download_pdf(self, request, pk=None):
+        """Download the quote PDF."""
+        try:
+            pdf_bytes, filename = render_quote_document_pdf(pk)
+        except QuotePdfError as e:
+            # 422 pour signaler une erreur métier de génération
+            return HttpResponse(str(e), status=422, content_type="text/plain; charset=utf-8")
+        response = HttpResponse(pdf_bytes, content_type="application/pdf")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        response["Cache-Control"] = "no-store"
+        return response
+
 
 class QuotePreviewPdfView(APIView):
     permission_classes = [IsAuthenticated]
@@ -480,7 +500,7 @@ class QuotePreviewPdfView(APIView):
             branding=data.get("branding"),
         )
         try:
-            pdf_bytes = render_quote_pdf(context)
+            pdf_bytes = render_quote_preview_pdf(context)
         except Exception:
             logger.exception("Unexpected error in quote preview PDF generation")
             raise

--- a/backend/apps/quote/services/pdf_generator.py
+++ b/backend/apps/quote/services/pdf_generator.py
@@ -1,0 +1,83 @@
+# apps/quote/services/pdf_generator.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader import render_to_string
+from weasyprint import HTML
+
+from apps.quote.models import Quote
+
+
+class QuotePdfError(Exception):
+    """Exception raised when there is an error generating the PDF."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class QuotePdfOptions:
+    template: str = "quote/pdf/document.html"
+    filename_prefix: str = "Devis"
+
+
+def _build_filename(quote: Quote, prefix: str) -> str:
+    """Build a filename for the PDF based on the quote and the prefix."""
+    # ex : Devis-FS-2025-0012-2025-10-18.pdf
+    ref = getattr(quote, "reference", f"QUOTE-{quote.pk}")
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    return f"{prefix}-{ref}-{date_str}.pdf".replace(" ", "-")
+
+
+def render_quote_pdf(quote_id: int | str, *, options: QuotePdfOptions = QuotePdfOptions()) -> tuple[bytes, str]:
+    """Render a quote PDF."""
+    try:
+        quote = Quote.objects.select_related("client").get(pk=quote_id)
+    except Quote.DoesNotExist as e:
+        raise QuotePdfError(f"Devis introuvable: {quote_id}") from e
+
+    # Contexte : reprends ce que tu utilises déjà en preview (seller, client, meta, lines, totals, branding)
+    try:
+        context = {
+            "quote": quote,
+            "client": getattr(quote, "client", None),
+            "meta": {
+                "number": getattr(quote, "reference", f"QUOTE-{quote.pk}"),
+                "date": quote.issue_date,
+                "valid_until": quote.valid_until,
+                "payment_terms": quote.payment_terms,
+                "currency": quote.currency,
+                "language": quote.language,
+                "title": quote.title,
+            },
+            "lines": quote.items.all(),
+            "totals": {
+                "subtotal": quote.subtotal,
+                "tax_total": quote.tax_total,
+                "discount_total": quote.discount_total,
+                "total": quote.total,
+            },
+            "branding": getattr(quote, "branding", None),
+            "is_download": True,
+        }
+    except Exception as e:
+        raise QuotePdfError(f"Erreur lors de la construction du contexte: {e}") from e
+
+    # 1) Rendu HTML
+    try:
+        html = render_to_string(options.template, context)
+    except Exception as e:
+        raise QuotePdfError(f"Erreur lors du rendu HTML: {e}") from e
+
+    # 2) Conversion HTML en PDF
+    base_url = str(Path(settings.BASE_DIR).resolve())
+    try:
+        pdf_bytes = HTML(string=html, base_url=base_url).write_pdf()
+    except Exception as e:
+        raise QuotePdfError(f"Erreur lors de la conversion HTML en PDF: {e}") from e
+
+    filename = _build_filename(quote, options.filename_prefix)
+    return pdf_bytes, filename

--- a/backend/apps/quote/tests/test_pdf_dowload.py
+++ b/backend/apps/quote/tests/test_pdf_dowload.py
@@ -1,0 +1,19 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_download_quote_pdf(authenticated_user, quote_factory):
+    quote = quote_factory()  # adapte à tes fixtures
+    client = APIClient()
+    client.force_authenticate(user=authenticated_user)
+    url = reverse("quote-download-pdf", kwargs={"pk": quote.pk})  # si basename/action diffèrent, ajuste
+    # Avec DRF router + action(detail=True, url_path="pdf") => name = "<basename>-download-pdf" si tu l’as nommé
+    # Sinon fais client.get(f"/api/quotes/{quote.pk}/pdf/")
+
+    res = client.get(f"/api/quotes/{quote.pk}/pdf/")
+    assert res.status_code == 200
+    assert res["Content-Type"].startswith("application/pdf")
+    assert "Content-Disposition" in res
+    assert res.content[:4] == b"%PDF"  # signature PDF

--- a/backend/templates/quote/pdf/document.html
+++ b/backend/templates/quote/pdf/document.html
@@ -1,0 +1,137 @@
+{% load static %}
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>Devis — Document</title>
+  <link rel="stylesheet" href="{% static 'css/pdf.css' %}">
+  <style>
+    @page { size: A4; margin: 18mm 16mm; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; color: #111; }
+    h1,h2,h3 { margin: 0 0 6px; }
+    .header { display:flex; justify-content: space-between; align-items:flex-start; margin-bottom: 18px; }
+    .brand { font-weight: 700; font-size: 20px; }
+    .muted { color: #666; }
+    .box { padding: 10px; border: 1px solid #e5e7eb; border-radius: 6px; }
+    table { width:100%; border-collapse: collapse; margin-top: 12px; }
+    th, td { padding: 8px; border-bottom: 1px solid #eee; text-align: left; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; }
+    .totals { margin-top: 12px; width: 50%; margin-left: auto; }
+    .totals td { padding: 6px 8px; }
+    .right { text-align: right; }
+  </style>
+</head>
+<body>
+  <!-- En-tête marque + vendeur (facultatif si seller absent dans le contexte) -->
+  <div class="header">
+    <div>
+      <div class="brand">{{ branding.name|default:"FreelanSign" }}</div>
+      {% if branding.logo_url %}
+        <img src="{{ branding.logo_url }}" alt="Logo" style="height:40px;margin-top:6px">
+      {% endif %}
+    </div>
+    <div class="muted">
+      {% if seller %}
+        <div>{{ seller.name }}</div>
+        {% if seller.siret %}<div>SIRET : {{ seller.siret }}</div>{% endif %}
+        {% if seller.vat_number %}<div>TVA : {{ seller.vat_number }}</div>{% endif %}
+        {% if seller.address %}<div>{{ seller.address }}</div>{% endif %}
+        {% if seller.email %}<div>{{ seller.email }}</div>{% endif %}
+      {% else %}
+        <!-- Fallback minimal si 'seller' n'est pas fourni -->
+        <div>{{ quote.owner.get_full_name|default:quote.owner.username }}</div>
+        {% if quote.owner.email %}<div>{{ quote.owner.email }}</div>{% endif %}
+      {% endif %}
+    </div>
+  </div>
+
+  <h1>Devis</h1>
+  <div class="muted">
+    Réf : {{ meta.number|default:quote.reference|default:"—" }}
+    • Date : {{ meta.date|default:quote.issue_date|default:"—" }}
+  </div>
+
+  <!-- Encadrés Client / Conditions -->
+  <div style="display:flex; gap:12px; margin-top:12px">
+    <div class="box" style="flex:1">
+      <h3>Client</h3>
+      {% if client %}
+        <div>{{ client.name }}</div>
+        {% if client.company %}<div>{{ client.company }}</div>{% endif %}
+        {% if client.address_line1 %}<div>{{ client.address_line1 }}</div>{% endif %}
+        {% if client.postal_code or client.city %}
+          <div>{{ client.postal_code }} {{ client.city }}</div>
+        {% endif %}
+        {% if client.email %}<div>{{ client.email }}</div>{% endif %}
+      {% else %}
+        <div class="muted">—</div>
+      {% endif %}
+    </div>
+
+    <div class="box" style="flex:1">
+      <h3>Conditions</h3>
+      <div class="muted">
+        {{ meta.terms|default:"Conditions générales sur demande." }}
+      </div>
+      {% if meta.valid_until or quote.valid_until %}
+        <div>Validité : {{ meta.valid_until|default:quote.valid_until }}</div>
+      {% endif %}
+      {% if meta.payment_terms or quote.payment_terms %}
+        <div>Règlement : {{ meta.payment_terms|default:quote.payment_terms }}</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Tableau des lignes -->
+  <table>
+    <thead>
+      <tr>
+        <th style="width:42%">Désignation</th>
+        <th style="width:28%">Description</th>
+        <th class="right">Qté</th>
+        <th class="right">PU HT</th>
+        <th class="right">TVA</th>
+        <th class="right">Total HT</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for l in lines %}
+      <tr>
+        <td>{{ l.designation|default:l.description|default:"" }}</td>
+        <td class="muted">{{ l.description }}</td>
+        <td class="right">{{ l.quantity|default:l.qty|floatformat:2 }}</td>
+        <td class="right">{{ l.unit_price|floatformat:2 }}</td>
+        <td class="right">
+          {% if l.tax_rate_display is not None %}
+            {{ l.tax_rate_display|floatformat:0 }}%
+          {% elif l.tax_rate is not None %}
+            {# Si tax_rate est stocké en pourcentage déjà formatté (ex: 20.00), on l'affiche tel quel #}
+            {{ l.tax_rate }}
+          {% else %}
+            —
+          {% endif %}
+        </td>
+        <td class="right">
+          {% if l.total_ht is not None %}
+            {{ l.total_ht|floatformat:2 }}
+          {% elif l.pre_tax_total is not None %}
+            {{ l.pre_tax_total|floatformat:2 }}
+          {% else %}
+            —
+          {% endif %}
+        </td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="6" class="muted">Aucune ligne.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <!-- Totaux (alignés à tes clés côté service: subtotal / tax_total / total) -->
+  <table class="totals">
+    <tr><td>Sous-total HT</td><td class="right">{{ totals.subtotal|default_if_none:"0.00"|floatformat:2 }}</td></tr>
+    <tr><td>TVA</td><td class="right">{{ totals.tax_total|default_if_none:"0.00"|floatformat:2 }}</td></tr>
+    <tr><td><strong>Total TTC</strong></td><td class="right"><strong>{{ totals.total|default_if_none:"0.00"|floatformat:2 }}</strong></td></tr>
+  </table>
+</body>
+</html>

--- a/frontend/src/infrastructure/quote/quoteRepository.ts
+++ b/frontend/src/infrastructure/quote/quoteRepository.ts
@@ -83,4 +83,32 @@ export const quoteRepository = {
     );
     return data;
   },
+
+  async downloadPdf(id: string | number): Promise<void> {
+    const url = API_ENDPOINTS.quotePdf(id);
+    try {
+      const res = await apiClient.get(url, { responseType: 'blob' });
+      const blob = res.data as Blob;
+      const cd = (res.headers['content-disposition'] as string) || '';
+      const match = /filename="?(.*?)"?$/.exec(cd);
+      const filename = match?.[1] || `devis-${id}.pdf`;
+
+      const urlObj = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = urlObj;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(urlObj);
+    } catch (error: unknown) {
+      const resp = (error as { response?: { data: Blob } | undefined })
+        ?.response;
+      if (resp?.data instanceof Blob) {
+        const text = await resp.data.text().catch(() => null);
+        throw new Error(text || 'Erreur lors du téléchargement du PDF');
+      }
+      throw error;
+    }
+  },
 };

--- a/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
@@ -57,6 +57,18 @@ export default function QuoteDetailPage() {
   const [loading, setLoading] = useState(false);
   const [quote, setQuote] = useState<UiQuoteDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  async function handleDownload() {
+    try {
+      setDownloading(true);
+      await quoteRepository.downloadPdf(id ?? '');
+    } catch (err) {
+      alert((err as Error).message || 'Erreur téléchargement PDF');
+    } finally {
+      setDownloading(false);
+    }
+  }
 
   useEffect(() => {
     if (!id) return;
@@ -344,6 +356,14 @@ export default function QuoteDetailPage() {
             </table>
           </div>
         )}
+        <button
+          onClick={handleDownload}
+          disabled={downloading}
+          className={styles.buttonAccent}
+          title="Télécharger le devis (PDF)"
+        >
+          {downloading ? 'Téléchargement en cours...' : 'Télécharger (PDF)'}
+        </button>
       </section>
 
       {!!quote.note && (

--- a/frontend/src/shared/endpoints.ts
+++ b/frontend/src/shared/endpoints.ts
@@ -1,6 +1,5 @@
 /**
  * Centralise les endpoints pour pouvoir les ajuster sans toucher au code métier.
- * ⚠️ Ajuste-les à tes vrais chemins DRF.
  */
 export const API_ENDPOINTS = {
   // Auth (DRF SimpleJWT custom views)
@@ -25,4 +24,5 @@ export const API_ENDPOINTS = {
   clients: '/api/clients/',
   quotes: '/api/quotes/',
   quotePreview: '/api/quotes/preview-pdf/',
+  quotePdf: (id: string | number) => `/api/quotes/${id}/pdf/`,
 } as const;


### PR DESCRIPTION
# Merge Request — feat/generate-pdf
## Objectif
Ajout de la génération et du téléchargement de devis au format PDF, directement depuis le back-end Django et intégrée côté front dans la page de détail d’un devis.

## Changements principaux
### Backend (apps/quote/)
- Nouveau service `pdf_generator.py`
- Ajoute la fonction `render_quote_pdf(quote_id)` qui :
	- Récupère le devis et ses lignes (`quote.items.all()`),
	- Rend un template HTML (`quote/pdf/document.html`),
	- Convertit le HTML en PDF via WeasyPrint,
	- Retourne le binaire PDF + un nom de fichier propre (`Devis-REF-...pdf`).
	- Gestion robuste des erreurs avec une exception dédiée `QuotePdfError`.
- Nouveau template `quote/pdf/document.html`
    - Reprise du design de la preview PDF avec un rendu professionnel
        - En-tête marque + vendeur
        - Cartes Client / Conditions
        - Tableau des lignes (désignation, quantité, TVA, total)
        - Tableau des totaux aligné à droite
        - Fallbacks et valeurs par défaut pour éviter les erreurs (`default_if_none`, `|default:`).

## Frontend 

- Ajout de quoteRepository.downloadPdf()
- Nouvelle méthode pour télécharger un devis au format PDF
	- Requête GET /api/quotes/:id/pdf/
	- Gère les blobs (axios responseType: 'blob')
	- Crée dynamiquement un lien `<a>` pour forcer le téléchargement
	- Gère les erreurs 4xx/5xx (lecture du texte renvoyé pour affichage clair)
- Intégration dans QuoteDetailPage
- Ajout d’un bouton `"Télécharger le PDF"` déclenchant la méthode ci-dessus.

## Auteurs 
- [@Bertrand2808](https://gitlab.com/Bertrand2808)