### PR TITLE
Feat/user password reset

### DIFF
--- a/backend/apps/user/adapters/providers/logging_token_sender.py
+++ b/backend/apps/user/adapters/providers/logging_token_sender.py
@@ -1,0 +1,24 @@
+# apps/user/adapters/providers/logging_token_sender.py
+import logging
+from urllib.parse import urlencode
+
+from apps.user.application.ports.token_sender import TokenSender
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingTokenSender(TokenSender):
+    """
+    Logging-based TokenSender for development/testing.
+    Logs the reset URL instead of sending an actual email.
+    """
+
+    def __init__(self, reset_base_url: str):
+        self.rset_base_url = reset_base_url.strip("/")
+
+    def send_reset_link(self, email: str, token: str) -> None:
+        """
+        Logs the password reset link with the signed token.
+        """
+        url = f"{self.rset_base_url}?{urlencode({'token': token})}"
+        logger.info("Sending password reset link to %s: %s", email, url)

--- a/backend/apps/user/adapters/providers/smtp_token_provider.py
+++ b/backend/apps/user/adapters/providers/smtp_token_provider.py
@@ -1,0 +1,35 @@
+# apps/user/adapters/providers/smtp_token_provider.py
+
+import logging
+
+from django.core.mail import EmailMessage
+
+from apps.user.application.ports.token_sender import TokenSender
+
+logger = logging.getLogger(__name__)
+
+
+class SmtpTokenSender(TokenSender):
+    """
+    Sends reset tokens via email using Django's SMTP backend.
+    """
+
+    def __init__(self, reset_base_url: str, from_email: str):
+        self.reset_base_url = reset_base_url
+        self.from_email = from_email
+
+    def send_reset_link(self, email: str, token: str) -> None:
+        link = f"{self.reset_base_url}?token={token}"
+        subject = "Password Reset Instructions"
+        body = (
+            "Hello,\n\n" f"To reset your password, click here:\n{link}\n\n" "If you did not request this, ignore this email."
+        )
+
+        logger.info("Sending password reset email to %s: %s", email, link)
+
+        EmailMessage(
+            subject=subject,
+            body=body,
+            from_email=self.from_email,
+            to=[email],
+        ).send()

--- a/backend/apps/user/application/dto/user_inputs.py
+++ b/backend/apps/user/application/dto/user_inputs.py
@@ -88,3 +88,11 @@ class GetProfessionalInput:
 
     user_id: Optional[int] = None
     professional_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ResetPasswordInput:
+    """Paramètres pour mettre à jour un mot de passe."""
+
+    token: str
+    new_password: str

--- a/backend/apps/user/application/ports/token_sender.py
+++ b/backend/apps/user/application/ports/token_sender.py
@@ -1,0 +1,21 @@
+# apps/user/application/ports/token_sender.py
+
+from typing import Protocol
+
+
+class TokenSender(Protocol):
+    """
+    Port: TokenSender
+    Defines the contract for sending password reset links.
+    """
+
+    def send_reset_link(self, email: str, token: str) -> None:
+        """
+        Sends a password reset link to the user.
+        Should include a URL containing the token.
+
+        Args:
+            email: Target email address.
+            token: Reset token (signed, time-limited).
+        """
+        ...

--- a/backend/apps/user/application/usecases/request_password_reset.py
+++ b/backend/apps/user/application/usecases/request_password_reset.py
@@ -1,0 +1,51 @@
+# apps/user/application/usecases/request_password_reset.py
+import logging
+from datetime import timedelta
+
+from django.core import signing
+from django.utils import timezone
+
+from apps.user.application.ports.token_sender import TokenSender
+from apps.user.application.ports.user_repository import UserRepository
+
+logger = logging.getLogger(__name__)
+
+
+class RequestPasswordReset:
+    """
+    Use case: request password reset by email.
+    If user exists, send a signed token via TokenSender.
+    """
+
+    TOKEN_EXPIRATION_HOURS = 2
+    SIGNER_SALT = "user.reset"
+
+    def __init__(self, user_repository: UserRepository, token_sender: TokenSender):
+        self.user_repository = user_repository
+        self.token_sender = token_sender
+
+    def execute(self, email: str) -> None:
+        """
+        Executes the password reset request.
+        Sends an email if the user exists, silently skips otherwise.
+
+        Args:
+            email: User's email.
+        """
+        email_clean = (email or "").strip().lower()
+        logger.info("RequestPasswordReset: received request for email=%s", email_clean)
+
+        user = self.user_repository.get_by_email(email=email_clean)
+        if not user:
+            logger.info("RequestPasswordReset: no user found for email=%s", email_clean)
+            return
+
+        payload = {
+            "user_id": user.id,
+            "ts": timezone.now().timestamp(),
+        }
+
+        token = signing.dumps(payload, salt=self.SIGNER_SALT)
+        logger.debug("RequestPasswordReset: generated token for user_id=%s", user.id)
+        self.token_sender.send_reset_link(email=user.email, token=token)
+        logger.info("RequestPasswordReset: link sent for user_id=%s", user.id)

--- a/backend/apps/user/application/usecases/reset_password.py
+++ b/backend/apps/user/application/usecases/reset_password.py
@@ -1,0 +1,61 @@
+# apps/user/application/usecases/reset_password.py
+import logging
+
+from django.core import signing
+
+from apps.user.application.dto.user_inputs import ResetPasswordInput
+from apps.user.application.errors import RepositoryError, UserNotFoundError
+from apps.user.application.ports.user_repository import UserRepository
+from apps.user.domain.policies.user_policy import UserPolicy
+
+logger = logging.getLogger(__name__)
+
+
+class ResetPassword:
+    """
+    Use case: reset a password from a token.
+    """
+
+    SIGNER_SALT = "user.reset"
+
+    def __init__(self, user_repository: UserRepository, token_max_age_sec: int):
+        self.user_repository = user_repository
+        self.token_max_age_sec = token_max_age_sec
+
+    def execute(self, input_dto: ResetPasswordInput) -> None:
+        """
+        Resets the user's password if the token is valid and not expired.
+
+        Args:
+            input_dto: ResetPasswordInput(token, new_password)
+
+        Raises:
+            UserNotFoundError: If the user ID in the token is invalid.
+            InvalidPasswordError: If the password does not meet policy.
+            RepositoryError: For technical issues.
+        """
+        try:
+            payload = signing.loads(
+                input_dto.token,
+                salt=self.SIGNER_SALT,
+                max_age=self.token_max_age_sec,
+            )
+        except signing.BadSignature:
+            logging.warning("ResetPassword: invalid token")
+            raise UserNotFoundError()
+
+        user_id = payload.get("user_id")
+        if not user_id:
+            logger.warning("ResetPassword: missing user_id in token")
+        logger.info("ResetPassword: token valid for user_id=%s", user_id)
+
+        # Validate password policy
+        UserPolicy.validate_password(input_dto.new_password)
+
+        # Reset password
+        try:
+            self.user_repository.update_password(user_id=user_id, new_password=input_dto.new_password)
+            logger.info("ResetPassword: password updated for user_id=%s", user_id)
+        except Exception as e:
+            logger.exception("ResetPassword: technical error for user_id=%s", user_id)
+            raise RepositoryError("Failed to reset password", original_error=e)

--- a/backend/apps/user/interface/auth_urls.py
+++ b/backend/apps/user/interface/auth_urls.py
@@ -1,0 +1,18 @@
+# apps/user/interface/auth_urls.py
+from django.urls import path
+
+from apps.user.interface.auth_views import (
+    AuthLoginView,
+    AuthLogoutView,
+    RequestPasswordResetView,
+    ResetPasswordView,
+    SecureAuthRefreshView,
+)
+
+urlpatterns = [
+    path("login/", AuthLoginView.as_view(), name="auth-login"),
+    path("logout/", AuthLogoutView.as_view(), name="auth-logout"),
+    path("refresh/", SecureAuthRefreshView.as_view(), name="auth-refresh"),
+    path("request-password-reset/", RequestPasswordResetView.as_view(), name="auth-request-password-reset"),
+    path("reset-password/", ResetPasswordView.as_view(), name="auth-reset-password"),
+]

--- a/backend/apps/user/interface/auth_views.py
+++ b/backend/apps/user/interface/auth_views.py
@@ -1,4 +1,5 @@
 # apps/user/interface/auth_views.py
+import logging
 from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
@@ -14,7 +15,18 @@ from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, Ou
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView
 
-from .serializers import LogoutSerializer
+from apps.user.adapters.persistence.django_user_repository import DjangoUserRepository
+from apps.user.adapters.providers.logging_token_sender import LoggingTokenSender
+from apps.user.adapters.providers.smtp_token_provider import SmtpTokenSender
+from apps.user.application.dto.user_inputs import ResetPasswordInput
+from apps.user.application.usecases.request_password_reset import RequestPasswordReset
+from apps.user.application.usecases.reset_password import ResetPassword
+from apps.user.interface.errors_handler import UserErrorHandler
+from config import settings
+
+from .serializers import LogoutSerializer, RequestPasswordResetSerializer, ResetPasswordSerializer
+
+logger = logging.getLogger(__name__)
 
 
 @extend_schema(
@@ -167,3 +179,134 @@ class SecureAuthRefreshView(APIView):
                 pass
 
         return Response(data, status=status.HTTP_200_OK)
+
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Request password reset",
+    description="Sends a reset link to the user if the email exists. The token is valid for 30 minutes.",
+    responses={
+        200: OpenApiResponse({"detail": "If the email exists, a reset link was sent."}),
+        400: OpenApiResponse({"email": ["This field is required."]}),
+    },
+)
+class RequestPasswordResetView(APIView):
+    """
+    RequestPasswordResetView handles password reset token generation.
+
+    Public endpoint (no auth). If the email matches a user, a reset link
+    is sent via the configured TokenSender.
+    """
+
+    permission_classes = [AllowAny]
+    throttle_classes = {
+        ScopedRateThrottle,
+    }
+    throttle_scope = "auth"
+
+    def post(self, request):
+        """
+        Accepts an email and triggers the password reset process.
+
+        Returns:
+            200 OK - Always, even if the email is unknown (for security).
+            400 Bad Request - If the email field is missing or invalid.
+        """
+        logger.info("RAW BODY: %s", request.body)
+        logger.info("REQUEST DATA: %s", request.data)
+
+        ser = RequestPasswordResetSerializer(data=request.data)
+        if not ser.is_valid():
+            logger.warning("Invalid password reset request: %s", ser.errors)
+            return Response(
+                {
+                    "error": "INVALID_INPUT",
+                    "message": "Invalid request payload",
+                    "detail": ser.errors,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        logger.info("Validated input: %s", ser.validated_data)
+
+        try:
+            use_case = RequestPasswordReset(
+                user_repository=DjangoUserRepository(),
+                token_sender=SmtpTokenSender(
+                    reset_base_url=settings.RESET_PASSWORD_URL,
+                    from_email=settings.EMAIL_FROM,
+                ),
+            )
+            use_case.execute(email=ser.validated_data["email"])
+
+            return Response(
+                {"detail": "If the email exists, a reset link was sent."},
+                status=status.HTTP_200_OK,
+            )
+
+        except Exception as e:
+            return UserErrorHandler.handle_error(e)
+
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+
+
+@extend_schema(
+    tags=["Auth"],
+    summary="Reset password using token",
+    description=(
+        "Accepts a signed token (from the password reset email) and a new password. "
+        "If the token is valid and not expired (2 hours), the user's password is updated. "
+        "This endpoint does not require authentication."
+    ),
+    request=ResetPasswordSerializer,
+    responses={
+        200: OpenApiResponse({"detail": "Password has been reset."}),
+        400: OpenApiResponse({"token": ["This field is required."], "new_password": ["This field is required."]}),
+        404: OpenApiResponse({"error": "USER_NOT_FOUND", "message": "User not found", "detail": "..."}),
+        422: OpenApiResponse({"error": "INVALID_PASSWORD", "message": "Password too weak", "detail": "..."}),
+    },
+)
+class ResetPasswordView(APIView):
+    """
+    ResetPasswordView handles password reset via signed token.
+
+    This public endpoint accepts a reset token and a new password.
+    If the token is valid and not expired, the password is updated.
+    No authentication is required to use this endpoint.
+    """
+
+    permission_classes = [AllowAny]
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "auth"
+
+    def post(self, request):
+        """
+        Validates the signed token and updates the user's password.
+
+        Returns:
+            200 OK - Password has been successfully reset.
+            400 Bad Request - Missing or invalid fields.
+            404 Not Found - Invalid or expired token.
+            422 Unprocessable Entity - Password does not meet complexity rules.
+        """
+        ser = ResetPasswordSerializer(data=request.data)
+        if not ser.is_valid():
+            return Response(ser.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            input_dto = ResetPasswordInput(
+                token=ser.validated_data["token"],
+                new_password=ser.validated_data["new_password"],
+            )
+
+            use_case = ResetPassword(
+                user_repository=DjangoUserRepository(),
+                token_max_age_sec=2 * 3600,  # 🔐 2 hours validity
+            )
+            use_case.execute(input_dto)
+
+            return Response({"detail": "Password has been reset."}, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return UserErrorHandler.handle_error(e)

--- a/backend/apps/user/interface/serializers.py
+++ b/backend/apps/user/interface/serializers.py
@@ -8,6 +8,7 @@ No business rules here (kept in domain). No DB access here.
 from __future__ import annotations
 
 from typing import Optional
+from urllib.parse import unquote
 
 from rest_framework import serializers
 
@@ -18,12 +19,7 @@ from apps.user.application.dto.user_inputs import (
     UpdateProfessionalInput,
     UpdateProfileInput,
 )
-from apps.user.application.dto.user_viewmodels import (
-    ProfessionalViewModel,
-    ProfileViewModel,
-    UserListViewModel,
-    UserViewModel,
-)
+from apps.user.application.dto.user_viewmodels import ProfessionalViewModel, ProfileViewModel, UserListViewModel, UserViewModel
 
 # Only imported for enum/choices exposure at the boundary (not for persistence)
 from apps.user.models.models import Profile
@@ -266,3 +262,27 @@ __all__ = [
     "UserListOutputSerializer",
     "ProfessionalOutputSerializer",
 ]
+
+
+class RequestPasswordResetSerializer(serializers.Serializer):
+    """
+    Input shape for requesting a password reset
+    """
+
+    email = serializers.EmailField()
+
+
+class ResetPasswordSerializer(serializers.Serializer):
+    """
+    Input shape for resetting a password from a signed token.
+    """
+
+    token = serializers.CharField()
+    new_password = serializers.CharField()
+
+    # appelé automatiquement par .is_valid()
+    def validate_token(self, value: str) -> str:
+        """
+        Decode the token from URL-encoded format.
+        """
+        return unquote(value)

--- a/backend/apps/user/interface/urls.py
+++ b/backend/apps/user/interface/urls.py
@@ -1,9 +1,0 @@
-# apps/user/interface/urls.py
-from rest_framework.routers import SimpleRouter
-
-from .views import UserViewSet
-
-router = SimpleRouter()
-router.register("", UserViewSet, basename="user")
-
-urlpatterns = router.urls

--- a/backend/apps/user/tests/application/usecases/test_request_password_reset.py
+++ b/backend/apps/user/tests/application/usecases/test_request_password_reset.py
@@ -1,0 +1,34 @@
+# apps/user/tests/application/usecases/test_request_password_reset.py
+
+from unittest.mock import Mock
+
+import pytest
+
+from apps.user.application.usecases.request_password_reset import RequestPasswordReset
+
+
+def test_sends_token_if_user_found():
+    repo = Mock()
+    sender = Mock()
+    repo.get_by_email.return_value = Mock(id=42, email="bob@example.com")
+
+    use_case = RequestPasswordReset(user_repository=repo, token_sender=sender)
+    use_case.execute("bob@example.com")
+
+    sender.send_reset_link.assert_called_once()
+    called_email = sender.send_reset_link.call_args.kwargs["email"]
+    called_token = sender.send_reset_link.call_args.kwargs["token"]
+    assert isinstance(called_token, str)
+    assert called_email == "bob@example.com"
+    assert len(called_token) > 10
+
+
+def test_silent_if_user_not_found():
+    repo = Mock()
+    sender = Mock()
+    repo.get_by_email.return_value = None
+
+    use_case = RequestPasswordReset(user_repository=repo, token_sender=sender)
+    use_case.execute("ghost@example.com")
+
+    sender.send_reset_link.assert_not_called()

--- a/backend/apps/user/tests/application/usecases/test_reset_password.py
+++ b/backend/apps/user/tests/application/usecases/test_reset_password.py
@@ -1,0 +1,56 @@
+# apps/user/tests/application/usecases/test_reset_password.py
+from time import time
+
+import pytest
+from django.core import signing
+
+from apps.user.application.dto.user_inputs import ResetPasswordInput
+from apps.user.application.errors import UserNotFoundError
+from apps.user.application.usecases.reset_password import ResetPassword
+
+
+def make_token(user_id: int) -> str:
+    return signing.dumps({"user_id": user_id, "ts": time()}, salt="user.reset")
+
+
+def test_resets_password_successfully():
+    repo = DummyRepo(user_exists=True)
+    use_case = ResetPassword(repo, token_max_age_sec=3600)
+
+    token = make_token(42)
+    dto = ResetPasswordInput(token=token, new_password="Valid123!")
+    use_case.execute(dto)
+
+    assert repo.updated_password_for == 42
+
+
+def test_invalid_token_raises_user_not_found():
+    repo = DummyRepo()
+    use_case = ResetPassword(repo, token_max_age_sec=3600)
+
+    with pytest.raises(UserNotFoundError):
+        use_case.execute(ResetPasswordInput(token="invalid", new_password="Valid123!"))
+
+
+def test_expired_token_rejected():
+    repo = DummyRepo()
+    use_case = ResetPassword(repo, token_max_age_sec=1)  # 1 second
+
+    token = make_token(42)
+    import time as t
+
+    t.sleep(2)
+
+    with pytest.raises(UserNotFoundError):
+        use_case.execute(ResetPasswordInput(token=token, new_password="Valid123!"))
+
+
+class DummyRepo:
+    def __init__(self, user_exists=True):
+        self.user_exists = user_exists
+        self.updated_password_for = None
+
+    def update_password(self, user_id, new_password):
+        if not self.user_exists:
+            raise UserNotFoundError()
+        self.updated_password_for = user_id

--- a/backend/apps/user/tests/interface/serializers/test_reset_password_serializer.py
+++ b/backend/apps/user/tests/interface/serializers/test_reset_password_serializer.py
@@ -1,0 +1,27 @@
+from urllib.parse import quote
+
+from rest_framework.exceptions import ValidationError
+
+from apps.user.interface.serializers import ResetPasswordSerializer
+
+
+def test_token_is_url_decoded():
+    raw_token = "abc:def:ghi"
+    encoded_token = quote(raw_token)  # Simule un lien réel
+
+    serializer = ResetPasswordSerializer(
+        data={
+            "token": encoded_token,
+            "new_password": "Valid123!",
+        }
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["token"] == raw_token
+
+
+def test_serializer_fails_on_missing_fields():
+    serializer = ResetPasswordSerializer(data={})
+    assert not serializer.is_valid()
+    assert "token" in serializer.errors
+    assert "new_password" in serializer.errors

--- a/backend/apps/user/urls.py
+++ b/backend/apps/user/urls.py
@@ -1,24 +1,15 @@
-# apps/user/urls.py
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from apps.user.interface.views import (
-    OnboardingProfessionalView,
-    ProfessionalUserMeView,
-    UserViewSet,
-)
+from apps.user.interface.views import OnboardingProfessionalView, ProfessionalUserMeView, UserViewSet
 
 app_name = "user"
 
 router = DefaultRouter()
-# Users CRUD-like (list, create, me, etc.)
 router.register(r"", UserViewSet, basename="user")
 
 urlpatterns = [
-    # /api/user/ -> router (UserViewSet)
-    path("", include(router.urls)),
-    # Professional "me"
+    path("", include(router.urls)),  # user/ CRUD
     path("professional/me/", ProfessionalUserMeView.as_view(), name="professional-me"),
-    # Onboarding pro
     path("onboarding-professional/", OnboardingProfessionalView.as_view(), name="onboarding-professional"),
 ]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -33,6 +33,21 @@ DEBUG = env("DEBUG", default=False)
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
 
 # --------------------------------------------------------------------------------------
+# Email settings
+# --------------------------------------------------------------------------------------
+# Looking to send emails in production? Check out our Email API/SMTP product!
+# Pour le développement avec Mailtrap uniquement
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "sandbox.smtp.mailtrap.io"
+EMAIL_HOST_USER = "54e99456c8cc20"
+EMAIL_HOST_PASSWORD = "04ef95b11a8fce"
+EMAIL_PORT = 2525  # Port non-sécurisé de Mailtrap
+EMAIL_USE_TLS = False  # Pas de TLS en dev
+EMAIL_USE_SSL = False  # Pas de SSL en dev
+EMAIL_FROM = "noreply@example.com"
+RESET_PASSWORD_URL = "https://frontend/reset-password"
+
+# --------------------------------------------------------------------------------------
 # Database
 # - Priorité à DATABASE_URL
 # - Sinon, variables séparées

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -4,8 +4,6 @@ from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
 
-from apps.user.interface.auth_views import AuthLoginView, AuthLogoutView, SecureAuthRefreshView
-
 urlpatterns = [
     path("admin/", admin.site.urls),
     # OpenAPI schema & Swagger UI en public
@@ -22,9 +20,7 @@ urlpatterns = [
     # Votre API users
     path("api/user/", include("apps.user.urls", namespace="user")),
     # Auth endpoints
-    path("api/auth/login/", AuthLoginView.as_view(), name="auth_login"),
-    path("api/auth/refresh/", SecureAuthRefreshView.as_view(), name="auth_refresh"),
-    path("api/auth/logout/", AuthLogoutView.as_view(), name="auth_logout"),
+    path("api/auth/", include("apps.user.interface.auth_urls")),
     # Catalog
     path("api/catalog/", include("apps.catalog.interface.urls", namespace="catalog")),
     # Quotes

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:08:35 CET**
+_Updated_: **2025-11-10 10:09:01 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:07:37 CET**
+_Updated_: **2025-11-10 10:07:53 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:15:32 CET**
+_Updated_: **2025-11-11 09:15:50 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:14:54 CET**
+_Updated_: **2025-11-11 09:15:17 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:15:50 CET**
+_Updated_: **2025-11-11 09:16:48 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:16:48 CET**
+_Updated_: **2025-11-11 09:16:59 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:09:01 CET**
+_Updated_: **2025-11-10 10:09:22 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:15:17 CET**
+_Updated_: **2025-11-11 09:15:32 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -762,8 +762,11 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   └── user
 │   │       ├── __init__.py
 │   │       ├── adapters
-│   │       │   └── persistence
-│   │       │       └── django_user_repository.py
+│   │       │   ├── persistence
+│   │       │   │   └── django_user_repository.py
+│   │       │   └── providers
+│   │       │       ├── logging_token_sender.py
+│   │       │       └── smtp_token_provider.py
 │   │       ├── admin.py
 │   │       ├── application
 │   │       │   ├── dto
@@ -771,12 +774,15 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │       │   │   └── user_viewmodels.py
 │   │       │   ├── errors.py
 │   │       │   ├── ports
+│   │       │   │   ├── token_sender.py
 │   │       │   │   └── user_repository.py
 │   │       │   └── usecases
 │   │       │       ├── change_password.py
 │   │       │       ├── create_professional.py
 │   │       │       ├── list_users.py
 │   │       │       ├── register_user.py
+│   │       │       ├── request_password_reset.py
+│   │       │       ├── reset_password.py
 │   │       │       ├── update_professional.py
 │   │       │       └── update_profile.py
 │   │       ├── apps.py
@@ -792,10 +798,10 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │       │       └── user_calculator.py
 │   │       ├── interface
 │   │       │   ├── __init__.py
+│   │       │   ├── auth_urls.py
 │   │       │   ├── auth_views.py
 │   │       │   ├── errors_handler.py
 │   │       │   ├── serializers.py
-│   │       │   ├── urls.py
 │   │       │   └── views.py
 │   │       ├── migrations
 │   │       │   ├── __init__.py
@@ -816,6 +822,13 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │       ├── signals.py
 │   │       ├── tests
 │   │       │   ├── __init__.py
+│   │       │   ├── application
+│   │       │   │   └── usecases
+│   │       │   │       ├── test_request_password_reset.py
+│   │       │   │       └── test_reset_password.py
+│   │       │   ├── interface
+│   │       │   │   └── serializers
+│   │       │   │       └── test_reset_password_serializer.py
 │   │       │   ├── test_auth_api.py
 │   │       │   ├── test_auth_logout.py
 │   │       │   ├── test_professional_api.py
@@ -1037,7 +1050,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   └── precommit.sh
 └── sonar-project.properties
 
-163 directories, 418 files
+168 directories, 426 files
 ```
 <!-- END AUTO: PROJECT_STRUCTURE -->
 
@@ -1107,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-09 11:28:25 CET**
+_Updated_: **2025-11-10 10:07:37 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:08:24 CET**
+_Updated_: **2025-11-10 10:08:35 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:09:22 CET**
+_Updated_: **2025-11-10 10:09:36 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -958,6 +958,11 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   ├── interface
 │   │   │   ├── components
 │   │   │   │   ├── AppToBar.tsx
+│   │   │   │   ├── auth
+│   │   │   │   │   ├── request-password-reset-form.module.css
+│   │   │   │   │   ├── RequestPasswordResetForm.tsx
+│   │   │   │   │   ├── reset-password-form.module.css
+│   │   │   │   │   └── ResetPasswordForm.tsx
 │   │   │   │   ├── branding
 │   │   │   │   │   └── ThemesForm.tsx
 │   │   │   │   ├── common
@@ -993,6 +998,10 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   ├── layout
 │   │   │   │   └── RootSeo.tsx
 │   │   │   ├── pages
+│   │   │   │   ├── Auth
+│   │   │   │   │   ├── request-password-reset.module.css
+│   │   │   │   │   ├── request-password-reset.tsx
+│   │   │   │   │   └── reset-password.tsx
 │   │   │   │   ├── Branding
 │   │   │   │   │   ├── themes.module.css
 │   │   │   │   │   ├── ThemesCreatePage.tsx
@@ -1021,6 +1030,8 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │       ├── branding.ts
 │   │   │       └── saveFile.ts
 │   │   ├── lib
+│   │   │   ├── api
+│   │   │   │   └── auth.ts
 │   │   │   ├── constants
 │   │   │   │   └── site.config.ts
 │   │   │   └── utils.ts
@@ -1050,7 +1061,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   └── precommit.sh
 └── sonar-project.properties
 
-168 directories, 426 files
+171 directories, 434 files
 ```
 <!-- END AUTO: PROJECT_STRUCTURE -->
 
@@ -1120,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:09:36 CET**
+_Updated_: **2025-11-11 09:14:54 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1131,5 +1131,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-11 09:16:59 CET**
+_Updated_: **2025-11-11 10:28:54 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:07:53 CET**
+_Updated_: **2025-11-10 10:08:08 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1120,5 +1120,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-10 10:08:08 CET**
+_Updated_: **2025-11-10 10:08:24 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import {
   createBrowserRouter,
-  RouterProvider,
   Navigate,
+  RouterProvider,
 } from 'react-router-dom';
-import LoginPage from '../interface/pages/Login/LoginPage';
-import RegisterPage from '../interface/pages/Register/RegisterPage';
-import DashboardPage from '../interface/pages/DashboardPage';
-import { useAuth } from './providers/AuthProvider';
-import ProfilePage from '../interface/pages/Profile/ProfilePage';
-import ProfileEditPage from '../interface/pages/Profile/ProfileEditPage';
-import QuoteCreatePage from '../interface/pages/Quote/QuoteCreatePage';
-import QuotesListPage from '../interface/pages/Quote/QuoteListPage';
-import QuoteDetailPage from '../interface/pages/Quote/QuoteDetailPage';
-import QuoteEditPage from '../interface/pages/Quote/QuoteEditPage';
-import ThemesListPage from '../interface/pages/Branding/ThemesListPage';
+import RequestPasswordResetPage from '../interface/pages/Auth/request-password-reset';
+import ResetPasswordPage from '../interface/pages/Auth/reset-password';
 import ThemesCreatePage from '../interface/pages/Branding/ThemesCreatePage';
 import ThemesEditPage from '../interface/pages/Branding/ThemesEditPage';
+import ThemesListPage from '../interface/pages/Branding/ThemesListPage';
+import DashboardPage from '../interface/pages/DashboardPage';
+import LoginPage from '../interface/pages/Login/LoginPage';
+import ProfileEditPage from '../interface/pages/Profile/ProfileEditPage';
+import ProfilePage from '../interface/pages/Profile/ProfilePage';
+import QuoteCreatePage from '../interface/pages/Quote/QuoteCreatePage';
+import QuoteDetailPage from '../interface/pages/Quote/QuoteDetailPage';
+import QuoteEditPage from '../interface/pages/Quote/QuoteEditPage';
+import QuotesListPage from '../interface/pages/Quote/QuoteListPage';
+import RegisterPage from '../interface/pages/Register/RegisterPage';
+import { useAuth } from './providers/AuthProvider';
 
 /** Route protégée très simple */
 function Protected({ children }: { children: React.ReactNode }) {
@@ -102,6 +104,11 @@ const router = createBrowserRouter([
       </Protected>
     ),
   },
+  {
+    path: '/auth/request-password-reset',
+    element: <RequestPasswordResetPage />,
+  },
+  { path: '/auth/reset-password', element: <ResetPasswordPage /> },
 ]);
 
 export default function AppRouter() {

--- a/frontend/src/domain/types.ts
+++ b/frontend/src/domain/types.ts
@@ -44,4 +44,5 @@ export interface AuthPort {
   refresh(refreshToken: string): Promise<TokenPair>;
   logout(refreshToken: string): Promise<void>;
   getMe(): Promise<AuthUser>;
+  requestPasswordReset(email: string): Promise<void>;
 }

--- a/frontend/src/infrastructure/auth/authRepository.ts
+++ b/frontend/src/infrastructure/auth/authRepository.ts
@@ -1,13 +1,13 @@
-import { API_ENDPOINTS } from '../../shared/endpoints';
-import { apiClient } from '../../infrastructure/http/apiClient';
-import { tokenStorage } from '../../infrastructure/storage/tokenStorage';
 import type {
   AuthPort,
+  AuthUser,
   LoginPayload,
   RegisterPayload,
   TokenPair,
-  AuthUser,
 } from '../../domain/types';
+import { apiClient } from '../../infrastructure/http/apiClient';
+import { tokenStorage } from '../../infrastructure/storage/tokenStorage';
+import { API_ENDPOINTS } from '../../shared/endpoints';
 
 /**
  * Implémentation concrète des appels Auth contre DRF.
@@ -56,5 +56,9 @@ export const authRepository: AuthPort = {
   async getMe(): Promise<AuthUser> {
     const { data } = await apiClient.get(API_ENDPOINTS.me);
     return data as AuthUser;
+  },
+
+  async requestPasswordReset(email: string): Promise<void> {
+    await apiClient.post(API_ENDPOINTS.requestPasswordReset, { email });
   },
 };

--- a/frontend/src/infrastructure/user/userRepository.ts
+++ b/frontend/src/infrastructure/user/userRepository.ts
@@ -1,8 +1,8 @@
 // src/infrastructure/user/userRepository.ts
 import axios from 'axios';
+import type { ProfessionalUserDto, UserDto } from '../../domain/user/types';
 import { apiClient } from '../../infrastructure/http/apiClient';
 import { API_ENDPOINTS } from '../../shared/endpoints';
-import type { ProfessionalUserDto, UserDto } from '../../domain/user/types';
 
 type ProfilePayload = Partial<UserDto['profile']>;
 type UpdateMeArg = ProfilePayload | { profile: ProfilePayload };
@@ -125,4 +125,6 @@ export const userRepository = {
     console.log('[userRepository] updateProfessionalMe response:', data);
     return normalizeProfessionalDto(data);
   },
+
+  // TODO: Add routes for reset password here instead of frontend/src/lib/api/auth.ts
 };

--- a/frontend/src/interface/components/auth/RequestPasswordResetForm.tsx
+++ b/frontend/src/interface/components/auth/RequestPasswordResetForm.tsx
@@ -1,0 +1,67 @@
+// frontend/components/auth/RequestPasswordResetForm.tsx
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { authRepository } from '../../../infrastructure/auth/authRepository';
+import styles from './request-password-reset-form.module.css';
+
+const schema = z.object({
+  email: z.string().min(1, 'Email requis').email('Email invalide'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function RequestPasswordResetForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await authRepository.requestPasswordReset(data.email);
+    setSubmitted(true);
+  });
+
+  if (submitted) {
+    return (
+      <p className={styles.success}>
+        Si l'email existe, un lien de réinitialisation a été envoyé.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={styles.form} noValidate>
+      <div className={styles.stack}>
+        <label htmlFor="email" className={styles.label}>
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          placeholder="jean.dupont@example.com"
+          {...register('email')}
+          className={styles.input}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'email-error' : undefined}
+        />
+        {errors.email && (
+          <small id="email-error" className={styles.error}>
+            {errors.email.message}
+          </small>
+        )}
+      </div>
+
+      <button type="submit" disabled={isSubmitting} className={styles.submit}>
+        {isSubmitting ? 'Envoi en cours…' : 'Envoyer le lien'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/interface/components/auth/ResetPasswordForm.tsx
+++ b/frontend/src/interface/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,76 @@
+// frontend/components/auth/ResetPasswordForm.tsx
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { resetPassword } from '../../../lib/api/auth';
+import styles from './reset-password-form.module.css';
+
+const schema = z.object({
+  token: z.string().min(1),
+  new_password: z
+    .string()
+    .min(6, 'Le mot de passe doit contenir au moins 6 caractères'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface Props {
+  token: string;
+}
+
+export default function ResetPasswordForm({ token }: Props) {
+  const [done, setDone] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { token },
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await resetPassword(data.token, data.new_password);
+    setDone(true);
+  });
+
+  if (done) {
+    return (
+      <p className={styles.success}>Votre mot de passe a été réinitialisé.</p>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={styles.form} noValidate>
+      <input type="hidden" value={token} {...register('token')} />
+
+      <div className={styles.stack}>
+        <label htmlFor="new_password" className={styles.label}>
+          Nouveau mot de passe
+        </label>
+        <input
+          id="new_password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="••••••••"
+          {...register('new_password')}
+          className={styles.input}
+          aria-invalid={!!errors.new_password}
+          aria-describedby={errors.new_password ? 'password-error' : undefined}
+        />
+        {errors.new_password && (
+          <small id="password-error" className={styles.error}>
+            {errors.new_password.message}
+          </small>
+        )}
+      </div>
+
+      <button type="submit" disabled={isSubmitting} className={styles.submit}>
+        {isSubmitting ? 'Réinitialisation…' : 'Réinitialiser le mot de passe'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/interface/components/auth/request-password-reset-form.module.css
+++ b/frontend/src/interface/components/auth/request-password-reset-form.module.css
@@ -1,0 +1,74 @@
+/* frontend/components/auth/reset-password-form.module.css */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text);
+  margin-right: 20px;
+}
+
+.input {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(13, 13, 13, 0.14);
+  font-size: 0.95rem;
+  background: #fff;
+  outline: none;
+  width: 300px;
+  transition:
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.input:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(36, 86, 194, 0.18);
+}
+
+.input::placeholder {
+  color: #8a8a8a;
+}
+
+.error {
+  color: red;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.submit {
+  background-color: var(--brand);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition:
+    transform 0.04s ease,
+    box-shadow 0.18s ease;
+}
+
+.submit:hover:not(:disabled) {
+  box-shadow: 0 6px 16px rgba(36, 86, 194, 0.35);
+  transform: translateY(-1px);
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #f0f0f0;
+  color: #888;
+}

--- a/frontend/src/interface/components/auth/reset-password-form.module.css
+++ b/frontend/src/interface/components/auth/reset-password-form.module.css
@@ -1,0 +1,47 @@
+/* frontend/components/auth/reset-password-form.module.css */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  color: var(--text);
+}
+
+.input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.submit {
+  background-color: var(--brand);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/interface/pages/Auth/request-password-reset.module.css
+++ b/frontend/src/interface/pages/Auth/request-password-reset.module.css
@@ -1,0 +1,43 @@
+/* frontend/src/interface/pages/Auth/request-password-reset.module.css */
+
+.main {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--paper);
+  padding: 0 1rem;
+  color: var(--text);
+}
+
+.container {
+  width: 100%;
+  max-width: 420px;
+}
+
+.header {
+  background: linear-gradient(135deg, var(--brand), #1d449a);
+  color: #fff;
+  padding: 20px 24px;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(36, 86, 194, 0.25);
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.meta {
+  opacity: 0.95;
+  margin-top: 4px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid rgba(13, 13, 13, 0.06);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+}

--- a/frontend/src/interface/pages/Auth/request-password-reset.tsx
+++ b/frontend/src/interface/pages/Auth/request-password-reset.tsx
@@ -1,0 +1,19 @@
+// frontend/src/interface/pages/Auth/request-password-reset.tsx
+import RequestPasswordResetForm from '../../components/auth/RequestPasswordResetForm';
+import styles from './request-password-reset.module.css';
+
+export default function RequestPasswordResetPage() {
+  return (
+    <main className={styles.main}>
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <h1 className={styles.title}>Réinitialiser le mot de passe</h1>
+          <p className={styles.meta}>Recevez un lien sécurisé par email</p>
+        </div>
+        <div className={styles.card}>
+          <RequestPasswordResetForm />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/interface/pages/Auth/reset-password.tsx
+++ b/frontend/src/interface/pages/Auth/reset-password.tsx
@@ -1,0 +1,24 @@
+// frontend/app/pages/auth/reset-password.tsx
+
+import { useSearchParams } from 'react-router-dom';
+import ResetPasswordForm from '../../components/auth/ResetPasswordForm';
+
+export default function ResetPasswordPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+
+  if (!token) {
+    return <p className="text-red-600">Lien invalide ou expiré.</p>;
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-[var(--paper)] px-4">
+      <div className="max-w-md w-full bg-white p-6 rounded-2xl shadow-md">
+        <h1 className="text-xl font-semibold text-[var(--brand)] mb-4">
+          Définir un nouveau mot de passe
+        </h1>
+        <ResetPasswordForm token={token} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/interface/pages/Auth/reset-password.tsx
+++ b/frontend/src/interface/pages/Auth/reset-password.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import ResetPasswordForm from '../../components/auth/ResetPasswordForm';
 
 export default function ResetPasswordPage() {
-  const searchParams = useSearchParams();
+  const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
 
   if (!token) {

--- a/frontend/src/interface/pages/Login/LoginPage.module.css
+++ b/frontend/src/interface/pages/Login/LoginPage.module.css
@@ -99,3 +99,8 @@
   opacity: 0.9;
   transform: translateY(-1px);
 }
+
+.help {
+  margin-top: 0.5rem;
+  text-align: center;
+}

--- a/frontend/src/interface/pages/Login/LoginPage.tsx
+++ b/frontend/src/interface/pages/Login/LoginPage.tsx
@@ -1,11 +1,11 @@
-import { Link, useNavigate } from 'react-router-dom';
-import LoginForm from '../../components/login/LoginForm';
-import Navbar from '../../../interface/components/navbar/Navbar';
 import { useEffect } from 'react';
-import { useAuth } from '../../../app/providers/AuthProvider';
-import styles from './LoginPage.module.css';
 import { Helmet } from 'react-helmet-async';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../app/providers/AuthProvider';
+import Navbar from '../../../interface/components/navbar/Navbar';
 import { SITE } from '../../../lib/constants/site.config';
+import LoginForm from '../../components/login/LoginForm';
+import styles from './LoginPage.module.css';
 
 export default function LoginPage() {
   const { user } = useAuth();
@@ -34,6 +34,11 @@ export default function LoginPage() {
             <Link to="/register" className={styles.link}>
               Créer un compte
             </Link>
+          </p>
+          <p className={styles.help}>
+            <a href="/auth/request-password-reset" className={styles.link}>
+              Mot de passe oublié ?
+            </a>
           </p>
         </section>
       </main>

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -1,0 +1,17 @@
+// frontend/lib/api/auth.ts
+
+export async function resetPassword(
+  token: string,
+  new_password: string,
+): Promise<void> {
+  const res = await fetch('/api/auth/reset-password/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, new_password }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json();
+    throw new Error(body?.message || 'Erreur lors de la réinitialisation.');
+  }
+}

--- a/frontend/src/shared/endpoints.ts
+++ b/frontend/src/shared/endpoints.ts
@@ -25,4 +25,5 @@ export const API_ENDPOINTS = {
   quotes: '/api/quotes/',
   quotePreview: '/api/quotes/preview-pdf/',
   quotePdf: (id: string | number) => `/api/quotes/${id}/pdf/`,
+  requestPasswordReset: 'api/auth/request-password-reset/',
 } as const;


### PR DESCRIPTION
## 🔐 Feature : Réinitialisation du mot de passe par email

### 📍 Objectif

Cette MR implémente la fonctionnalité complète de réinitialisation du mot de passe pour les utilisateurs ayant oublié leurs identifiants.

---

### ⚙️ Backend (Django)

* Ajout des cas d’usage `RequestPasswordReset` et `ResetPassword`
* Création du port `TokenSender` avec deux implémentations :

  * `LoggingTokenSender` pour dev/local
  * `SmtpTokenSender` basé sur `EmailMessage` de Django
* Génération de token sécurisé via `TimestampSigner` (durée : 2h)
* Endpoints REST :

  * `POST /api/auth/request-password-reset/`
  * `POST /api/auth/reset-password/`
* Configuration du backend mail avec SMTP (Mailtrap en dev)
* Logging clair et progressif à chaque étape
* Serializers dédiés avec validation stricte
* Routage propre (`auth_urls.py` dédié)
* Ajout de squelettes de tests pour les cas d’usage

---

### 🧑‍🎨 Frontend (React)

* Création des pages :

  * `/request-password-reset` : formulaire de demande par email
  * `/reset-password?token=...` : formulaire de nouveau mot de passe
* Mise à jour de `router.tsx` pour intégrer les nouvelles routes
* Ajout d’un lien depuis la page de login
* Formulaires basés sur `react-hook-form` + `zod`
* Affichage des erreurs avec accessibilité (`aria-*`)
* Application des styles selon la charte graphique :

  * Boutons `var(--brand)`
  * Cartes (`.card`) cohérentes avec les autres pages
  * Feedback utilisateur (succès / erreur)
* Création et branchement des fichiers CSS (`.module.css`) pour les formulaires
* Refonte du repository `authRepository` pour y intégrer l'appel à l’API

---

### 🧪 Tests et validation

* Envoi de mail confirmé via Mailtrap
* Validation manuelle de bout en bout (formulaire, lien, reset)
* Gestion des cas d’erreur (token manquant ou invalide)
* Préparé pour une intégration future de tests Cypress ou Playwright

---

### ⚠️ À noter

* En local, les liens de reset utilisent `https://frontend/reset-password`, à adapter une fois le domaine de prod défini.
* La fonctionnalité est isolée sur la branche `feat/user-password-reset`.
* Intégration frontend respectueuse de la structure projet (pas de `src/features` ni `pages/` custom).