### PR TITLE
feat(user): Account Phase 1 - Domain Layer

### DIFF
--- a/backend/apps/user/domain/entities/__init__.py
+++ b/backend/apps/user/domain/entities/__init__.py
@@ -1,0 +1,1 @@
+# apps/user/domain/entities/__init__.py

--- a/backend/apps/user/domain/entities/account.py
+++ b/backend/apps/user/domain/entities/account.py
@@ -1,0 +1,32 @@
+# apps/user/domain/entities/account.py
+"""
+Entité Account du domaine user.
+"""
+from dataclasses import dataclass
+from datetime import datetime
+
+from apps.user.domain.policies.account_policy import AccountPolicy
+from apps.user.domain.value_objects import LegalForm
+
+
+@dataclass
+class Account:
+    """
+    Domain Entity pour un compte professionnel (entité freelance).
+    Un utilisateur peut avoir plusieurs Accounts (multi-entity future).
+    """
+
+    id: int
+    user_id: int
+    display_name: str  # Nom affiché (maps from ProfessionalUser.name)
+    legal_form: LegalForm  # Forme juridique (enum)
+    legal_id: str | None  # SIRET (14 chiffres)
+    domain_id: int | None  # FK vers catalog.Area
+    created_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self):
+        """Validation à la création."""
+        # Valide display_name uniquement (les autres validations sont optionnelles
+        # ou seront faites dans les use cases)
+        AccountPolicy.validate_display_name(self.display_name)

--- a/backend/apps/user/domain/errors.py
+++ b/backend/apps/user/domain/errors.py
@@ -103,3 +103,62 @@ class DuplicateProfessionalError(ProfessionalPolicyError):
 
     def __init__(self, user_id: int):
         super().__init__(f"Un profil professionnel existe déjà pour l'utilisateur {user_id}")
+
+
+# Erreurs pour Account
+class AccountPolicyError(UserDomainError):
+    """Erreur de politique liée aux comptes professionnels (Account)."""
+
+    def __init__(self, message: str):
+        super().__init__(message, code="ACCOUNT_POLICY_ERROR")
+
+
+class InvalidDisplayNameError(AccountPolicyError):
+    """Nom d'affichage invalide."""
+
+    def __init__(self, name: str, reason: str = ""):
+        msg = f"Nom d'affichage invalide: '{name}'"
+        if reason:
+            msg += f" ({reason})"
+        super().__init__(msg)
+
+
+class InvalidLegalFormError(AccountPolicyError):
+    """Forme juridique invalide."""
+
+    def __init__(self, legal_form: str):
+        super().__init__(f"Forme juridique invalide: '{legal_form}'")
+
+
+class InvalidLegalIdError(AccountPolicyError):
+    """Identifiant légal (SIRET) invalide."""
+
+    def __init__(self, legal_id: str, reason: str = ""):
+        msg = f"Identifiant légal invalide: '{legal_id}'"
+        if reason:
+            msg += f" ({reason})"
+        super().__init__(msg)
+
+
+class InvalidDomainIdError(AccountPolicyError):
+    """ID de domaine invalide."""
+
+    def __init__(self, domain_id: int | None):
+        super().__init__(f"ID de domaine invalide: {domain_id} (doit être > 0)")
+
+
+class DuplicateAccountNameError(AccountPolicyError):
+    """Un compte avec ce nom existe déjà pour cet utilisateur."""
+
+    def __init__(self, user_id: int, display_name: str):
+        super().__init__(f"Un compte nommé '{display_name}' existe déjà pour l'utilisateur {user_id}")
+
+
+class AccountNotFoundError(AccountPolicyError):
+    """Compte non trouvé."""
+
+    def __init__(self, account_id: int, context: str = ""):
+        msg = f"Compte {account_id} non trouvé"
+        if context:
+            msg += f" ({context})"
+        super().__init__(msg)

--- a/backend/apps/user/domain/policies/account_policy.py
+++ b/backend/apps/user/domain/policies/account_policy.py
@@ -1,0 +1,122 @@
+# apps/user/domain/policies/account_policy.py
+"""
+Politiques métier pour les comptes professionnels (Account).
+Règles pures, sans dépendance Django.
+"""
+import re
+from typing import Optional
+
+from apps.user.domain.errors import (
+    DuplicateAccountNameError,
+    InvalidDisplayNameError,
+    InvalidDomainIdError,
+    InvalidLegalFormError,
+    InvalidLegalIdError,
+)
+from apps.user.domain.value_objects import LegalForm
+
+
+class AccountPolicy:
+    """
+    Politique de validation des comptes professionnels.
+    Contient les règles métier pures.
+    """
+
+    MIN_DISPLAY_NAME_LENGTH = 2
+    MAX_DISPLAY_NAME_LENGTH = 255
+    SIRET_LENGTH = 14
+    VALID_LEGAL_FORMS = [form.value for form in LegalForm]
+
+    @classmethod
+    def validate_display_name(cls, name: str) -> None:
+        """Valide le nom d'affichage."""
+        if not name or not name.strip():
+            raise InvalidDisplayNameError(name, "ne peut pas être vide")
+
+        if len(name.strip()) < cls.MIN_DISPLAY_NAME_LENGTH:
+            raise InvalidDisplayNameError(name, f"minimum {cls.MIN_DISPLAY_NAME_LENGTH} caractères")
+
+        if len(name) > cls.MAX_DISPLAY_NAME_LENGTH:
+            raise InvalidDisplayNameError(name, f"maximum {cls.MAX_DISPLAY_NAME_LENGTH} caractères")
+
+    @classmethod
+    def validate_legal_form(cls, legal_form: str | LegalForm) -> None:
+        """Valide la forme juridique."""
+        # Convert enum to string if needed
+        form_value = legal_form.value if isinstance(legal_form, LegalForm) else legal_form
+
+        if form_value not in cls.VALID_LEGAL_FORMS:
+            raise InvalidLegalFormError(str(form_value))
+
+    @classmethod
+    def validate_legal_id(cls, legal_id: str | None) -> None:
+        """
+        Valide l'identifiant légal (SIRET).
+        Format: exactement 14 chiffres.
+        """
+        # None or empty string is allowed (optional field)
+        if not legal_id:
+            return
+
+        # Check exact length and numeric-only
+        if not re.match(r"^[0-9]{14}$", legal_id):
+            if len(legal_id) != cls.SIRET_LENGTH:
+                raise InvalidLegalIdError(legal_id, f"doit contenir exactement {cls.SIRET_LENGTH} chiffres")
+            else:
+                raise InvalidLegalIdError(legal_id, "doit contenir uniquement des chiffres")
+
+    @classmethod
+    def validate_domain_id(cls, domain_id: int | None) -> None:
+        """Valide l'ID du domaine d'activité."""
+        if domain_id is None:
+            return
+
+        if domain_id <= 0:
+            raise InvalidDomainIdError(domain_id)
+
+    @classmethod
+    def validate_account_data(
+        cls,
+        display_name: str,
+        legal_form: str | LegalForm,
+        legal_id: str | None = None,
+        domain_id: int | None = None,
+    ) -> None:
+        """
+        Valide toutes les données d'un compte.
+        Lève une exception en cas d'erreur.
+        """
+        cls.validate_display_name(display_name)
+        cls.validate_legal_form(legal_form)
+        cls.validate_legal_id(legal_id)
+        cls.validate_domain_id(domain_id)
+
+    @classmethod
+    def validate_unique_display_name(
+        cls,
+        user_id: int,
+        display_name: str,
+        existing_names: list[str],
+        exclude_account_id: int | None = None,
+    ) -> None:
+        """
+        Valide l'unicité du nom d'affichage (case-insensitive).
+
+        Note: L'implémentation actuelle ne gère pas encore l'exclusion par ID
+        car existing_names est une simple liste de strings sans les IDs.
+        Dans la couche application/repository, on filtrera les noms existants
+        en excluant le compte avec exclude_account_id AVANT d'appeler cette méthode.
+
+        Args:
+            user_id: ID de l'utilisateur
+            display_name: Nom à valider
+            existing_names: Liste des noms existants pour cet utilisateur
+                           (déjà filtrée pour exclure exclude_account_id si fourni)
+            exclude_account_id: ID du compte à exclure (pour update)
+                               NOTE: Le filtrage doit être fait en amont
+        """
+        normalized_name = display_name.lower().strip()
+
+        for existing in existing_names:
+            if existing.lower().strip() == normalized_name:
+                raise DuplicateAccountNameError(user_id, display_name)

--- a/backend/apps/user/domain/value_objects.py
+++ b/backend/apps/user/domain/value_objects.py
@@ -1,0 +1,16 @@
+# apps/user/domain/value_objects.py
+"""
+Value Objects du domaine user.
+Objets purs, sans dépendance Django.
+"""
+from enum import Enum
+
+
+class LegalForm(str, Enum):
+    """Formes juridiques pour les freelances français."""
+
+    MICRO = "micro"
+    EIRL = "eirl"
+    EURL = "eurl"
+    SASU = "sasu"
+    OTHER = "other"

--- a/backend/apps/user/tests/domain/__init__.py
+++ b/backend/apps/user/tests/domain/__init__.py
@@ -1,0 +1,1 @@
+# apps/user/tests/domain/__init__.py

--- a/backend/apps/user/tests/domain/test_account_entity.py
+++ b/backend/apps/user/tests/domain/test_account_entity.py
@@ -1,0 +1,124 @@
+# apps/user/tests/domain/test_account_entity.py
+"""
+Tests unitaires pour l'entité Account.
+Tests purs, sans dépendance Django.
+"""
+from datetime import datetime
+
+import pytest
+
+from apps.user.domain.entities.account import Account
+from apps.user.domain.errors import InvalidDisplayNameError
+from apps.user.domain.value_objects import LegalForm
+
+
+class TestAccountEntity:
+    """Tests pour l'entité Account."""
+
+    def test_account_creation_success(self):
+        """Test création d'un compte avec tous les champs."""
+        account = Account(
+            id=1,
+            user_id=42,
+            display_name="Ma SARL Consulting",
+            legal_form=LegalForm.EURL,
+            legal_id="12345678901234",
+            domain_id=5,
+            created_at=datetime(2024, 1, 1, 12, 0, 0),
+            updated_at=datetime(2024, 1, 15, 14, 30, 0),
+        )
+
+        assert account.id == 1
+        assert account.user_id == 42
+        assert account.display_name == "Ma SARL Consulting"
+        assert account.legal_form == LegalForm.EURL
+        assert account.legal_id == "12345678901234"
+        assert account.domain_id == 5
+        assert account.created_at == datetime(2024, 1, 1, 12, 0, 0)
+        assert account.updated_at == datetime(2024, 1, 15, 14, 30, 0)
+
+    def test_account_creation_minimal(self):
+        """Test création d'un compte avec champs minimaux."""
+        account = Account(
+            id=2,
+            user_id=10,
+            display_name="Freelance Dev",
+            legal_form=LegalForm.MICRO,
+            legal_id=None,  # Optionnel
+            domain_id=None,  # Optionnel
+            created_at=datetime(2024, 2, 1),
+            updated_at=datetime(2024, 2, 1),
+        )
+
+        assert account.id == 2
+        assert account.user_id == 10
+        assert account.display_name == "Freelance Dev"
+        assert account.legal_form == LegalForm.MICRO
+        assert account.legal_id is None
+        assert account.domain_id is None
+
+    def test_account_mutable(self):
+        """Test qu'on peut modifier les champs d'un Account (mutable dataclass)."""
+        account = Account(
+            id=3,
+            user_id=20,
+            display_name="Initial Name",
+            legal_form=LegalForm.MICRO,
+            legal_id=None,
+            domain_id=None,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        # Modifications
+        account.display_name = "Updated Name"
+        account.legal_form = LegalForm.EURL
+        account.legal_id = "98765432109876"
+        account.domain_id = 7
+
+        assert account.display_name == "Updated Name"
+        assert account.legal_form == LegalForm.EURL
+        assert account.legal_id == "98765432109876"
+        assert account.domain_id == 7
+
+    def test_account_post_init_empty_display_name_raises(self):
+        """Test que __post_init__ lève une erreur si display_name est vide."""
+        with pytest.raises(InvalidDisplayNameError):
+            Account(
+                id=4,
+                user_id=30,
+                display_name="",  # Vide
+                legal_form=LegalForm.MICRO,
+                legal_id=None,
+                domain_id=None,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+
+        with pytest.raises(InvalidDisplayNameError):
+            Account(
+                id=5,
+                user_id=30,
+                display_name="   ",  # Espaces seulement
+                legal_form=LegalForm.MICRO,
+                legal_id=None,
+                domain_id=None,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+
+    def test_account_post_init_display_name_too_long_raises(self):
+        """Test que __post_init__ lève une erreur si display_name est trop long."""
+        long_name = "X" * 256  # > 255 caractères
+
+        with pytest.raises(InvalidDisplayNameError):
+            Account(
+                id=6,
+                user_id=40,
+                display_name=long_name,
+                legal_form=LegalForm.SASU,
+                legal_id=None,
+                domain_id=None,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )

--- a/backend/apps/user/tests/domain/test_account_policy.py
+++ b/backend/apps/user/tests/domain/test_account_policy.py
@@ -1,0 +1,212 @@
+# apps/user/tests/domain/test_account_policy.py
+"""
+Tests unitaires pour les politiques du domaine Account.
+Tests purs, sans dépendance Django.
+"""
+import pytest
+
+from apps.user.domain.errors import (
+    DuplicateAccountNameError,
+    InvalidDisplayNameError,
+    InvalidDomainIdError,
+    InvalidLegalFormError,
+    InvalidLegalIdError,
+)
+from apps.user.domain.policies.account_policy import AccountPolicy
+from apps.user.domain.value_objects import LegalForm
+
+
+class TestAccountPolicy:
+    """Tests de la politique de validation des comptes (Account)."""
+
+    # ===== Display Name Validation =====
+
+    def test_validate_display_name_success(self):
+        """Test validation d'un nom d'affichage valide."""
+        AccountPolicy.validate_display_name("Ma Société")
+        AccountPolicy.validate_display_name("AB")  # 2 chars minimum
+
+    def test_validate_display_name_empty(self):
+        """Test validation d'un nom vide."""
+        with pytest.raises(InvalidDisplayNameError):
+            AccountPolicy.validate_display_name("")
+
+        with pytest.raises(InvalidDisplayNameError):
+            AccountPolicy.validate_display_name("   ")
+
+    def test_validate_display_name_too_short(self):
+        """Test validation d'un nom trop court."""
+        with pytest.raises(InvalidDisplayNameError):
+            AccountPolicy.validate_display_name("A")  # < 2 chars
+
+    def test_validate_display_name_too_long(self):
+        """Test validation d'un nom trop long."""
+        long_name = "X" * 256  # > 255 chars
+        with pytest.raises(InvalidDisplayNameError):
+            AccountPolicy.validate_display_name(long_name)
+
+    # ===== Legal Form Validation =====
+
+    def test_validate_legal_form_success_string(self):
+        """Test validation d'une forme juridique valide (string)."""
+        AccountPolicy.validate_legal_form("micro")
+        AccountPolicy.validate_legal_form("eirl")
+        AccountPolicy.validate_legal_form("eurl")
+        AccountPolicy.validate_legal_form("sasu")
+        AccountPolicy.validate_legal_form("other")
+
+    def test_validate_legal_form_success_enum(self):
+        """Test validation d'une forme juridique valide (enum)."""
+        AccountPolicy.validate_legal_form(LegalForm.MICRO)
+        AccountPolicy.validate_legal_form(LegalForm.EIRL)
+
+    def test_validate_legal_form_invalid(self):
+        """Test validation d'une forme juridique invalide."""
+        with pytest.raises(InvalidLegalFormError):
+            AccountPolicy.validate_legal_form("sarl")
+
+        with pytest.raises(InvalidLegalFormError):
+            AccountPolicy.validate_legal_form("invalid")
+
+    # ===== Legal ID / SIRET Validation =====
+
+    def test_validate_legal_id_success_valid_siret(self):
+        """Test validation d'un SIRET valide (14 chiffres)."""
+        AccountPolicy.validate_legal_id("12345678901234")  # 14 digits
+        AccountPolicy.validate_legal_id("00000000000000")
+
+    def test_validate_legal_id_success_none(self):
+        """Test validation avec None (champ optionnel)."""
+        AccountPolicy.validate_legal_id(None)  # Should not raise
+
+    def test_validate_legal_id_success_empty_string(self):
+        """Test validation avec string vide (considéré comme None)."""
+        AccountPolicy.validate_legal_id("")  # Should not raise
+
+    def test_validate_legal_id_invalid_too_short(self):
+        """Test validation d'un SIRET trop court."""
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_legal_id("1234567890123")  # 13 digits
+
+    def test_validate_legal_id_invalid_too_long(self):
+        """Test validation d'un SIRET trop long."""
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_legal_id("123456789012345")  # 15 digits
+
+    def test_validate_legal_id_invalid_non_numeric(self):
+        """Test validation d'un SIRET avec caractères non-numériques."""
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_legal_id("1234567890123A")
+
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_legal_id("ABCD1234567890")
+
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_legal_id("12345 67890123")  # avec espace
+
+    # ===== Domain ID Validation =====
+
+    def test_validate_domain_id_success(self):
+        """Test validation d'un domain_id valide."""
+        AccountPolicy.validate_domain_id(1)
+        AccountPolicy.validate_domain_id(999)
+        AccountPolicy.validate_domain_id(None)  # Optionnel
+
+    def test_validate_domain_id_zero_raises(self):
+        """Test validation domain_id = 0."""
+        with pytest.raises(InvalidDomainIdError):
+            AccountPolicy.validate_domain_id(0)
+
+    def test_validate_domain_id_negative_raises(self):
+        """Test validation domain_id négatif."""
+        with pytest.raises(InvalidDomainIdError):
+            AccountPolicy.validate_domain_id(-1)
+
+        with pytest.raises(InvalidDomainIdError):
+            AccountPolicy.validate_domain_id(-999)
+
+    # ===== Composite Validation =====
+
+    def test_validate_account_data_success(self):
+        """Test validation complète de données valides."""
+        AccountPolicy.validate_account_data(
+            display_name="Ma Société SARL",
+            legal_form="micro",
+            legal_id="12345678901234",
+            domain_id=5,
+        )
+
+        # Test avec champs optionnels à None
+        AccountPolicy.validate_account_data(
+            display_name="Freelance Designer",
+            legal_form=LegalForm.EURL,
+            legal_id=None,
+            domain_id=None,
+        )
+
+    def test_validate_account_data_invalid_display_name(self):
+        """Test validation complète avec display_name invalide."""
+        with pytest.raises(InvalidDisplayNameError):
+            AccountPolicy.validate_account_data(
+                display_name="",  # Invalid
+                legal_form="micro",
+                legal_id="12345678901234",
+                domain_id=1,
+            )
+
+    def test_validate_account_data_invalid_legal_id(self):
+        """Test validation complète avec legal_id invalide."""
+        with pytest.raises(InvalidLegalIdError):
+            AccountPolicy.validate_account_data(
+                display_name="Ma Société",
+                legal_form="micro",
+                legal_id="123",  # Too short
+                domain_id=1,
+            )
+
+    # ===== Unique Display Name Validation =====
+
+    def test_validate_unique_display_name_success(self):
+        """Test validation d'un nom unique (pas de conflit)."""
+        AccountPolicy.validate_unique_display_name(
+            user_id=1,
+            display_name="Nouveau Compte",
+            existing_names=["Autre Compte", "Compte Pro"],
+        )
+
+    def test_validate_unique_display_name_duplicate_exact(self):
+        """Test validation avec doublon exact."""
+        with pytest.raises(DuplicateAccountNameError):
+            AccountPolicy.validate_unique_display_name(
+                user_id=1,
+                display_name="Mon Compte",
+                existing_names=["Mon Compte", "Autre"],
+            )
+
+    def test_validate_unique_display_name_case_insensitive(self):
+        """Test validation case-insensitive (MyCompany = mycompany)."""
+        with pytest.raises(DuplicateAccountNameError):
+            AccountPolicy.validate_unique_display_name(
+                user_id=1,
+                display_name="MyCompany",
+                existing_names=["mycompany"],  # Lowercase version
+            )
+
+        with pytest.raises(DuplicateAccountNameError):
+            AccountPolicy.validate_unique_display_name(
+                user_id=1,
+                display_name="  FREELANCE  ",  # With spaces
+                existing_names=["freelance"],
+            )
+
+    def test_validate_unique_display_name_exclude_self_update(self):
+        """Test validation avec exclusion du compte en cours de mise à jour."""
+        # Scénario: on update le compte ID=5, il garde son nom actuel "Mon Compte"
+        # La repository layer doit FILTRER "Mon Compte" de existing_names avant d'appeler
+        # Donc ici, on passe seulement "Autre" (le nom du compte ID=5 est déjà exclu)
+        AccountPolicy.validate_unique_display_name(
+            user_id=1,
+            display_name="Mon Compte",
+            existing_names=["Autre"],  # "Mon Compte" déjà exclu par la repository
+            exclude_account_id=5,
+        )

--- a/backend/apps/user/tests/domain/test_legal_form_value_object.py
+++ b/backend/apps/user/tests/domain/test_legal_form_value_object.py
@@ -1,0 +1,38 @@
+# apps/user/tests/domain/test_legal_form_value_object.py
+"""
+Tests unitaires pour LegalForm value object.
+Tests purs, sans dépendance Django.
+"""
+import pytest
+
+from apps.user.domain.value_objects import LegalForm
+
+
+class TestLegalForm:
+    """Tests pour l'enum LegalForm."""
+
+    def test_legal_form_values(self):
+        """Test que tous les statuts juridiques attendus existent."""
+        assert hasattr(LegalForm, "MICRO")
+        assert hasattr(LegalForm, "EIRL")
+        assert hasattr(LegalForm, "EURL")
+        assert hasattr(LegalForm, "SASU")
+        assert hasattr(LegalForm, "OTHER")
+
+    def test_legal_form_string_values(self):
+        """Test que les valeurs sont bien des strings en lowercase."""
+        assert LegalForm.MICRO.value == "micro"
+        assert LegalForm.EIRL.value == "eirl"
+        assert LegalForm.EURL.value == "eurl"
+        assert LegalForm.SASU.value == "sasu"
+        assert LegalForm.OTHER.value == "other"
+
+    def test_legal_form_membership(self):
+        """Test que les valeurs peuvent être vérifiées."""
+        valid_forms = [form.value for form in LegalForm]
+        assert "micro" in valid_forms
+        assert "eirl" in valid_forms
+        assert "eurl" in valid_forms
+        assert "sasu" in valid_forms
+        assert "other" in valid_forms
+        assert "invalid" not in valid_forms

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -872,11 +872,16 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │       │       └── user
 │   │       │           └── logs
 │   │       ├── domain
+│   │       │   ├── entities
+│   │       │   │   ├── __init__.py
+│   │       │   │   └── account.py
 │   │       │   ├── errors.py
 │   │       │   ├── policies
+│   │       │   │   ├── account_policy.py
 │   │       │   │   └── user_policy.py
-│   │       │   └── services
-│   │       │       └── user_calculator.py
+│   │       │   ├── services
+│   │       │   │   └── user_calculator.py
+│   │       │   └── value_objects.py
 │   │       ├── interface
 │   │       │   ├── __init__.py
 │   │       │   ├── auth_urls.py
@@ -907,6 +912,11 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │       │   │   └── usecases
 │   │       │   │       ├── test_request_password_reset.py
 │   │       │   │       └── test_reset_password.py
+│   │       │   ├── domain
+│   │       │   │   ├── __init__.py
+│   │       │   │   ├── test_account_entity.py
+│   │       │   │   ├── test_account_policy.py
+│   │       │   │   └── test_legal_form_value_object.py
 │   │       │   ├── interface
 │   │       │   │   └── serializers
 │   │       │   │       └── test_reset_password_serializer.py
@@ -927,6 +937,14 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   └── wsgi.py
 │   ├── conftest.py
 │   ├── coverage.xml
+│   ├── diagrams
+│   │   ├── branding_diagram.mermaid
+│   │   ├── catalog_diagram.mermaid
+│   │   ├── client_diagram.mermaid
+│   │   ├── core_diagram.mermaid
+│   │   ├── quote_diagram.mermaid
+│   │   ├── user_class_diagram.mermaid
+│   │   └── user_diagram.mermaid
 │   ├── doc
 │   │   └── classes
 │   │       └── quote
@@ -937,9 +955,15 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │           ├── packages_quote_arch.dot
 │   │           └── packages_quote_arch.png
 │   ├── Dockerfile
+│   ├── generate_diagrams.py
 │   ├── logs
 │   │   └── app.log
 │   ├── manage.py
+│   ├── management
+│   │   ├── __init__.py
+│   │   └── commands
+│   │       ├── __init__.py
+│   │       └── generate_mermaid.py
 │   ├── media
 │   ├── pyproject.toml
 │   ├── pytest.ini
@@ -1168,6 +1192,22 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 ├── docker-compose.prod.yml
 ├── docker-compose.yml
 ├── docs
+│   ├── architecture
+│   │   ├── architecture.md
+│   │   ├── bc_branding.md
+│   │   ├── bc_catalog.md
+│   │   ├── bc_client.md
+│   │   ├── bc_core.md
+│   │   ├── bc_email.md
+│   │   ├── bc_quote.md
+│   │   ├── bc_user.md
+│   │   ├── template_bounded_context.md
+│   │   └── work
+│   │       ├── account_phase1_domain.md
+│   │       ├── auth_user_refacto.md
+│   │       ├── legal_terms_v0.md
+│   │       ├── subscription_v0.md
+│   │       └── user_refacto_analysis.md
 │   ├── backup.md
 │   ├── database_management.md
 │   ├── deployment
@@ -1405,7 +1445,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
         ├── test
         └── test.pyi
 
-247 directories, 702 files
+254 directories, 735 files
 ```
 <!-- END AUTO: PROJECT_STRUCTURE -->
 
@@ -1479,5 +1519,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-11-23 17:59:43 CET**
+_Updated_: **2025-11-25 16:03:59 CET**
 <!-- END AUTO: LAST_UPDATED -->


### PR DESCRIPTION
## Summary

Implements Phase 1 (domain layer) of issue #54 - Account entity to replace ProfessionalUser and enable multi-entity management.

## Changes

### Domain Layer (Pure Business Logic)

✅ **Value Objects**
- LegalForm enum (MICRO, EIRL, EURL, SASU, OTHER)

✅ **Domain Errors** (6 new)
- InvalidDisplayNameError
- InvalidLegalFormError  
- InvalidLegalIdError
- InvalidDomainIdError
- DuplicateAccountNameError
- AccountNotFoundError

✅ **Account Policy**
- Display name validation (2-255 chars)
- Legal form validation (enum)
- Legal ID validation (SIRET 14 digits)
- Domain ID validation (positive int)
- Composite validation
- Unique name (case-insensitive)

✅ **Account Entity**
- Dataclass with 8 fields
- __post_init__ validation
- Mutable (editable)

## Tests

✅ 31 tests passing (100% domain coverage)
- 3 tests: LegalForm value object
- 23 tests: AccountPolicy
- 5 tests: Account entity

## Verification

✅ No Django dependencies in domain layer
✅ No regression (existing tests still pass)
✅ TDD approach (tests written first)

## Next Steps

- Phase 2: Application layer (DTOs, use cases, ports)
- Phase 3: Persistence (models, migrations, repositories)  
- Phase 4: Interface (API, serializers)

Closes #54 (Phase 1 only)