### PR TITLE
feat(account): Account requirement enforcement and onboarding UX

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1608,5 +1608,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-12-02 21:35:44 CET**
+_Updated_: **2025-12-02 21:58:40 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1312,7 +1312,8 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   ├── docs
 │   │   └── tests
 │   │       ├── account_header.feature.md
-│   │       └── account_store.feature.md
+│   │       ├── account_store.feature.md
+│   │       └── use_require_account.feature.md
 │   ├── eslint.config.js
 │   ├── index.html
 │   ├── nginx.conf
@@ -1439,6 +1440,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   ├── hooks
 │   │   │   │   ├── useDebouncedValue.ts
 │   │   │   │   ├── usePdfPreview.ts
+│   │   │   │   ├── useRequireAccount.ts
 │   │   │   │   └── useThemes.ts
 │   │   │   ├── layout
 │   │   │   │   ├── main-layout.module.css
@@ -1497,7 +1499,10 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   └── index.css
 │   │   ├── tests
 │   │   │   ├── accountStore.test.ts
-│   │   │   └── apiClient.account-header.test.ts
+│   │   │   ├── apiClient.account-header.test.ts
+│   │   │   ├── noAccount_ProfileEditPage.test.tsx
+│   │   │   ├── noAccount_ProfilePage.test.tsx
+│   │   │   └── useRequireAccount.test.tsx
 │   │   └── vite-env.d.ts
 │   ├── tsconfig.app.json
 │   ├── tsconfig.json
@@ -1530,7 +1535,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
         ├── test
         └── test.pyi
 
-270 directories, 804 files
+270 directories, 809 files
 ```
 <!-- END AUTO: PROJECT_STRUCTURE -->
 
@@ -1603,5 +1608,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-12-02 12:00:48 CET**
+_Updated_: **2025-12-02 21:35:44 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/frontend/docs/tests/use_require_account.feature.md
+++ b/frontend/docs/tests/use_require_account.feature.md
@@ -1,0 +1,60 @@
+# useRequireAccount – BDD
+
+## Rôle
+
+Empêcher l'accès aux pages dépendantes d'un compte professionnel lorsqu'aucun compte n'est disponible,
+en redirigeant automatiquement l'utilisateur vers `/onboarding-account`.
+Laisser l'utilisateur sur la page lorsque un compte existe (via liste de comptes ou `activeAccountId`)
+ou lorsque la page est encore en cours de chargement.
+
+## Scénarios
+
+### Scénario 1 – Redirection quand aucun compte n'existe
+
+Étant donné qu'aucun compte n'est disponible (`accounts = []`)
+Et que `activeAccountId = null`
+Et que la page a fini de charger (`loading = false`)
+Quand le hook `useRequireAccount` est utilisé sur cette page
+Alors l'utilisateur est redirigé vers `/onboarding-account`.
+
+### Scénario 2 – Pas de redirection pendant le chargement
+
+Étant donné qu'aucun compte n'est disponible (`accounts = []`)
+Et que `activeAccountId = null`
+Et que la page est encore en cours de chargement (`loading = true`)
+Quand le hook `useRequireAccount` est utilisé sur cette page
+Alors aucune redirection n'est déclenchée.
+
+### Scénario 3 – Pas de redirection lorsqu'un compte existe via la liste
+
+Étant donné que la liste de comptes contient au moins un compte (`accounts = [acc_1, …]`)
+Et que la page a fini de charger (`loading = false`)
+Quand le hook `useRequireAccount` est utilisé sur cette page
+Alors aucune redirection n'est déclenchée
+Et l'utilisateur reste sur la page courante.
+
+### Scénario 4 – Pas de redirection lorsqu'un compte actif est connu
+
+Étant donné que `accounts = []` (la liste n'est pas encore hydratée)
+Et que `activeAccountId = acc_123` (valeur persistée depuis une session précédente)
+Et que la page a fini de charger (`loading = false`)
+Quand le hook `useRequireAccount` est utilisé sur cette page
+Alors aucune redirection n'est déclenchée
+Et l'utilisateur reste sur la page courante.
+
+### Scénario 5 – Hook désactivé
+
+Étant donné qu'aucun compte n'est disponible (`accounts = []`)
+Et que `activeAccountId = null`
+Et que la page a fini de charger (`loading = false`)
+Mais que le hook est utilisé avec l'option `enabled = false`
+Quand le hook `useRequireAccount` est utilisé sur cette page
+Alors aucune redirection n'est déclenchée.
+
+### Scénario 6 – Redirection personnalisée
+
+Étant donné qu'aucun compte n'est disponible (`accounts = []`)
+Et que `activeAccountId = null`
+Et que la page a fini de charger (`loading = false`)
+Quand le hook `useRequireAccount` est utilisé avec `redirectTo = "/custom-onboarding"`
+Alors l'utilisateur est redirigé vers `/custom-onboarding`.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import { globalIgnores } from 'eslint/config';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -11,13 +11,19 @@ export default tseslint.config([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      tseslint.configs.recommended, // ok de garder celui-là
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        // 👇 IMPORTANT : demande à TS-ESLint d'utiliser ton tsconfig
+        projectService: true,
+        // racine où se trouve ton tsconfig.json (ici frontend/)
+        tsconfigRootDir: new URL('.', import.meta.url).pathname,
+      },
     },
   },
-])
+]);

--- a/frontend/src/interface/hooks/useRequireAccount.ts
+++ b/frontend/src/interface/hooks/useRequireAccount.ts
@@ -1,0 +1,35 @@
+// src/interface/hooks/useRequireAccount.ts
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAccountStore } from '../../infrastructure/account/accountStore';
+
+type UseRequireAccountOptions = {
+  redirectTo?: string;
+  loading?: boolean; // loading local de la page
+  enabled?: boolean; // si false, le hook ne fait rien
+};
+
+export function useRequireAccount(options: UseRequireAccountOptions = {}) {
+  const {
+    redirectTo = '/onboarding-account',
+    loading = false,
+    enabled = true,
+  } = options;
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const accounts = useAccountStore((state) => state.accounts);
+  const activeAccountId = useAccountStore((state) => state.activeAccountId);
+
+  const hasAccount = accounts.length > 0 || activeAccountId !== null;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (loading) return;
+
+    if (!hasAccount && location.pathname !== redirectTo) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [enabled, loading, hasAccount, redirectTo, navigate, location.pathname]);
+}

--- a/frontend/src/interface/pages/DashboardPage.tsx
+++ b/frontend/src/interface/pages/DashboardPage.tsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../app/providers/AuthProvider';
+import { useAccountStore } from '../../infrastructure/account/accountStore';
 import QuotesTable from '../components/quote/QuotesTable';
 import styles from './dashboard.module.css';
 
 export default function DashboardPage() {
   const { user } = useAuth();
+  const activeAccountId = useAccountStore((state) => state.activeAccountId);
 
   return (
     <div className="grid gap-6">
@@ -28,6 +30,25 @@ export default function DashboardPage() {
       <p className={styles.welcome}>
         Bienvenue {user?.profile?.first_name ?? user?.email} 👋
       </p>
+      {activeAccountId === null && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h2 className={styles.cardTitle}>Commencez votre aventure freelance</h2>
+          </div>
+          <p className={styles.cardDescription}>
+            Créez votre compte professionnel en quelques minutes pour commencer à générer vos devis et factures.
+          </p>
+          <Link
+            to="/onboarding-account"
+            className={`${styles.btn} ${styles.btnAccent}`}
+          >
+            Créer mon compte
+          </Link>
+          <div className={styles.cardMeta}>
+            Vous pourrez modifier ces informations à tout moment depuis votre profil.
+          </div>
+        </div>
+      )}
       <div className={styles.card}>
         <div className={styles.containerOverride}>
           <QuotesTable />

--- a/frontend/src/interface/pages/DashboardPage.tsx
+++ b/frontend/src/interface/pages/DashboardPage.tsx
@@ -33,10 +33,13 @@ export default function DashboardPage() {
       {activeAccountId === null && (
         <div className={styles.card}>
           <div className={styles.cardHeader}>
-            <h2 className={styles.cardTitle}>Commencez votre aventure freelance</h2>
+            <h2 className={styles.cardTitle}>
+              Commencez votre aventure freelance
+            </h2>
           </div>
           <p className={styles.cardDescription}>
-            Créez votre compte professionnel en quelques minutes pour commencer à générer vos devis et factures.
+            Créez votre compte professionnel en quelques minutes pour commencer
+            à générer vos devis et factures.
           </p>
           <Link
             to="/onboarding-account"
@@ -45,7 +48,8 @@ export default function DashboardPage() {
             Créer mon compte
           </Link>
           <div className={styles.cardMeta}>
-            Vous pourrez modifier ces informations à tout moment depuis votre profil.
+            Vous pourrez modifier ces informations à tout moment depuis votre
+            profil.
           </div>
         </div>
       )}

--- a/frontend/src/interface/pages/Profile/ProfileEditPage.tsx
+++ b/frontend/src/interface/pages/Profile/ProfileEditPage.tsx
@@ -2,31 +2,30 @@
 import { useEffect, useMemo, useState } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-import type { AreaDto } from '../../../domain/catalog/types';
 import type { AccountDto } from '../../../domain/account/types';
+import type { AreaDto } from '../../../domain/catalog/types';
 import type { UserDto } from '../../../domain/user/types';
-import { catalogRepository } from '../../../infrastructure/catalog/catalogRepository';
-import { userRepository } from '../../../infrastructure/user/userRepository';
 import { accountRepository } from '../../../infrastructure/account/accountRepository';
 import { useAccountStore } from '../../../infrastructure/account/accountStore';
+import { catalogRepository } from '../../../infrastructure/catalog/catalogRepository';
+import { userRepository } from '../../../infrastructure/user/userRepository';
 
+import AccountDataForm, {
+  type AccountFormValues,
+} from '../../components/account/AccountDataForm';
 import { Card } from '../../components/common/Card';
 import { ConfirmModal } from '../../components/common/ConfirmModal';
 import PersonalUserDataForm, {
   type PersonalUserFormValues,
 } from '../../components/profile/PersonalUserDataForm';
 import PrestationsSelector from '../../components/profile/PrestationSelector';
-import AccountDataForm, {
-  type AccountFormValues,
-} from '../../components/account/AccountDataForm';
 
+import { useRequireAccount } from '../../hooks/useRequireAccount';
 import styles from './profile-edit-page.module.css';
 
 export default function ProfileEditPage() {
   const navigate = useNavigate();
   const activeAccountId = useAccountStore((state) => state.activeAccountId);
-  const accounts = useAccountStore((state) => state.accounts);
-
   const [user, setUser] = useState<UserDto | null>(null);
   const [account, setAccount] = useState<AccountDto | null | 'loading'>(
     'loading',
@@ -49,13 +48,7 @@ export default function ProfileEditPage() {
     Partial<PersonalUserFormValues>
   >({});
 
-  // Redirect to onboarding if no active account
-  useEffect(() => {
-    if (!loading && accounts.length === 0) {
-      navigate('/onboarding-account');
-    }
-  }, [accounts, loading, navigate]);
-
+  useRequireAccount({ loading });
   useEffect(() => {
     let mounted = true;
     (async () => {

--- a/frontend/src/interface/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/interface/pages/Profile/ProfilePage.tsx
@@ -2,14 +2,15 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../app/providers/AuthProvider';
-import type { PrestationDto } from '../../../domain/catalog/types';
 import type { AccountDto } from '../../../domain/account/types';
+import type { PrestationDto } from '../../../domain/catalog/types';
 import type { UserDto } from '../../../domain/user/types';
-import { catalogRepository } from '../../../infrastructure/catalog/catalogRepository';
-import { userRepository } from '../../../infrastructure/user/userRepository';
 import { accountRepository } from '../../../infrastructure/account/accountRepository';
 import { useAccountStore } from '../../../infrastructure/account/accountStore';
+import { catalogRepository } from '../../../infrastructure/catalog/catalogRepository';
+import { userRepository } from '../../../infrastructure/user/userRepository';
 
+import { useRequireAccount } from '../../hooks/useRequireAccount';
 import styles from './profile-page.module.css';
 
 /**
@@ -30,6 +31,8 @@ export default function ProfilePage() {
   const [areaName, setAreaName] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+
+  useRequireAccount({ loading });
 
   // helper type-guard
   function isApiError(e: unknown): e is { response?: { status?: number } } {

--- a/frontend/src/interface/pages/Quote/QuoteCreatePage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteCreatePage.tsx
@@ -10,21 +10,22 @@ import {
 } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import { z } from 'zod';
+import type { AccountDto } from '../../../domain/account/types';
 import type { PrestationDto } from '../../../domain/catalog/types';
 import type { ClientDto } from '../../../domain/client/types';
-import type { AccountDto } from '../../../domain/account/types';
 import type { UserDto } from '../../../domain/user/types';
+import { accountRepository } from '../../../infrastructure/account/accountRepository';
+import { useAccountStore } from '../../../infrastructure/account/accountStore';
 import { catalogRepository } from '../../../infrastructure/catalog/catalogRepository';
 import { clientRepository } from '../../../infrastructure/client/clientRepository';
-import { accountRepository } from '../../../infrastructure/account/accountRepository';
-import { userRepository } from '../../../infrastructure/user/userRepository';
-import { useAccountStore } from '../../../infrastructure/account/accountStore';
 import { quoteRepository } from '../../../infrastructure/quote/quoteRepository';
+import { userRepository } from '../../../infrastructure/user/userRepository';
 import ClientCreateDrawer from '../../components/client/ClientCreateDrawer';
 import Modal from '../../components/common/Modal';
 import { PdfPreviewPane } from '../../components/quote/PdfPreviewPane';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { usePdfPreview } from '../../hooks/usePdfPreview';
+import { useRequireAccount } from '../../hooks/useRequireAccount';
 import { openBlobUrlInNewTab, saveBlobUrlAs } from '../../utils/saveFile';
 import styles from './quote-edit-create.module.css';
 
@@ -144,6 +145,12 @@ export default function QuoteCreatePage() {
   const [account, setAccount] = useState<AccountDto | null>(null);
   const activeAccountId = useAccountStore((state) => state.activeAccountId);
   const [loading, setLoading] = useState(false);
+
+  // Loading initial de la page
+  const pageLoading = clients === 'loading' || prestations === 'loading';
+  // redirect si pas de compte
+  // TODO: ajouter un message d'erreur si pas de compte
+  useRequireAccount({ loading: pageLoading });
 
   // Remarque: on force le type Resolver<FormData> pour que zodResolver soit compatible
   const resolver = zodResolver(Schema) as unknown as Resolver<FormData>;

--- a/frontend/src/interface/pages/Quote/QuoteEditPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteEditPage.tsx
@@ -1,21 +1,22 @@
 // src/interface/pages/QuoteEditPage.tsx
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import type { AccountDto } from '../../../domain/account/types';
 import { apiToUiQuote } from '../../../domain/quote/mappers';
 import type {
   ApiQuoteResponse,
   ApiQuoteUpdatePayload,
 } from '../../../domain/quote/types';
-import type { AccountDto } from '../../../domain/account/types';
 import type { UserDto } from '../../../domain/user/types';
-import { quoteRepository } from '../../../infrastructure/quote/quoteRepository';
-import { userRepository } from '../../../infrastructure/user/userRepository';
 import { accountRepository } from '../../../infrastructure/account/accountRepository';
 import { useAccountStore } from '../../../infrastructure/account/accountStore';
+import { quoteRepository } from '../../../infrastructure/quote/quoteRepository';
+import { userRepository } from '../../../infrastructure/user/userRepository';
 import Modal from '../../components/common/Modal';
 import { PdfPreviewPane } from '../../components/quote/PdfPreviewPane';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { usePdfPreview, type PreviewPayload } from '../../hooks/usePdfPreview';
+import { useRequireAccount } from '../../hooks/useRequireAccount';
 import { openBlobUrlInNewTab, saveBlobUrlAs } from '../../utils/saveFile';
 import styles from './quote-edit-create.module.css';
 
@@ -83,7 +84,7 @@ export default function QuoteEditPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [quote, setQuote] = useState<Quote | null>(null);
@@ -91,6 +92,10 @@ export default function QuoteEditPage() {
   const [user, setUser] = useState<UserDto | null>(null);
   const [account, setAccount] = useState<AccountDto | null>(null);
   const activeAccountId = useAccountStore((state) => state.activeAccountId);
+
+  // TODO: ajouter un message d'erreur si pas de compte
+  // Redirect vers l'onboarding si aucun compte après chargement
+  useRequireAccount({ loading });
 
   // --- Load user and account ---
   useEffect(() => {

--- a/frontend/src/interface/pages/Quote/QuoteListPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteListPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useAccountStore } from '../../../infrastructure/account/accountStore';
 import { quoteRepository } from '../../../infrastructure/quote/quoteRepository';
 import styles from './quotes-list.module.css';
 
@@ -46,6 +47,7 @@ export default function QuotesListPage() {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<PageResponse<QuoteItem> | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const activeAccountId = useAccountStore((state) => state.activeAccountId);
 
   useEffect(() => {
     let active = true;
@@ -126,6 +128,29 @@ export default function QuotesListPage() {
           </Link>
         </div>
       </div>
+      {activeAccountId === null && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h2 className={styles.cardTitle}>
+              Commencez votre aventure freelance
+            </h2>
+          </div>
+          <p className={styles.cardDescription}>
+            Créez votre compte professionnel en quelques minutes pour commencer
+            à générer vos devis et factures.
+          </p>
+          <Link
+            to="/onboarding-account"
+            className={`${styles.btn} ${styles.btnAccent}`}
+          >
+            Créer mon compte
+          </Link>
+          <div className={styles.cardMeta}>
+            Vous pourrez modifier ces informations à tout moment depuis votre
+            profil.
+          </div>
+        </div>
+      )}
 
       {!data || (Array.isArray(data.results) && data.results.length === 0) ? (
         <div className={styles.empty}>Aucun devis trouvé.</div>

--- a/frontend/src/interface/pages/Quote/quotes-list.module.css
+++ b/frontend/src/interface/pages/Quote/quotes-list.module.css
@@ -79,6 +79,12 @@
   color: var(--dark);
 }
 
+.btnAccent {
+  background: var(--accent);
+  box-shadow: 0 6px 14px rgba(255, 138, 61, 0.12);
+  color: #111;
+}
+
 /* Carte liste */
 .card {
   background: #fff;
@@ -209,4 +215,34 @@
 .pagerBtn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+/* CTA card styling */
+/* header de la card (titre + link) */
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+/* petite meta under the card (count / info) */
+.cardMeta {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #6b7280; /* gray-500 */
+}
+.cardTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--dark);
+  margin: 0 0 0.5rem 0;
+}
+
+.cardDescription {
+  color: var(--text);
+  font-size: 0.95rem;
+  margin: 0 0 1rem 0;
+  line-height: 1.5;
 }

--- a/frontend/src/interface/pages/dashboard.module.css
+++ b/frontend/src/interface/pages/dashboard.module.css
@@ -110,6 +110,11 @@
   color: var(--dark);
   font-weight: 500;
 }
+.btnAccent {
+  background: var(--accent);
+  box-shadow: 0 6px 14px rgba(255, 138, 61, 0.12);
+  color: #111;
+}
 
 /* petite carte pour le tableau des devis */
 .card {
@@ -153,4 +158,19 @@
   display: flex;
   gap: 0.5rem;
   align-items: center;
+}
+
+/* CTA card styling */
+.cardTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--dark);
+  margin: 0 0 0.5rem 0;
+}
+
+.cardDescription {
+  color: var(--text);
+  font-size: 0.95rem;
+  margin: 0 0 1rem 0;
+  line-height: 1.5;
 }

--- a/frontend/src/tests/noAccount_ProfileEditPage.test.tsx
+++ b/frontend/src/tests/noAccount_ProfileEditPage.test.tsx
@@ -1,0 +1,73 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 1) Mock router
+const mockNavigate = vi.fn();
+let mockLocation = { pathname: '/profile' };
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
+  };
+});
+
+// 2) Mock account store
+let mockAccountState = {
+  accounts: [] as { id: number }[],
+  activeAccountId: null as number | null,
+};
+
+vi.mock('../infrastructure/account/accountStore', () => ({
+  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+    selector(mockAccountState),
+}));
+
+// ⬇️ 3) Mock useAuth avec LE BON CHEMIN depuis /src/tests
+vi.mock('../app/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { email: 'test@example.com' },
+  }),
+}));
+
+// 4) Ensuite seulement on importe ProfilePage
+import ProfileEditPage from '../interface/pages/Profile/ProfileEditPage';
+
+describe('ProfileEditPage – no-account handling', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockAccountState = { accounts: [], activeAccountId: null };
+    mockLocation = { pathname: '/profile' };
+  });
+
+  it('redirige vers onboarding quand aucun compte', async () => {
+    mockAccountState = { accounts: [], activeAccountId: null };
+
+    render(<ProfileEditPage />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/onboarding-account', {
+        replace: true,
+      });
+    });
+  });
+
+  it('ne redirige pas quand un compte existe', async () => {
+    mockAccountState = {
+      accounts: [{ id: 1 } as any],
+      activeAccountId: 1,
+    };
+
+    render(<ProfileEditPage />);
+
+    await waitFor(() => {
+      const calls = mockNavigate.mock.calls.map(([path]) => path);
+      expect(calls).not.toContain('/onboarding-account');
+    });
+  });
+});

--- a/frontend/src/tests/noAccount_ProfileEditPage.test.tsx
+++ b/frontend/src/tests/noAccount_ProfileEditPage.test.tsx
@@ -17,14 +17,19 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+type MockAccountState = {
+  accounts: { id: number }[];
+  activeAccountId: number | null;
+};
+
 // 2) Mock account store
-let mockAccountState = {
-  accounts: [] as { id: number }[],
-  activeAccountId: null as number | null,
+let mockAccountState: MockAccountState = {
+  accounts: [],
+  activeAccountId: null,
 };
 
 vi.mock('../infrastructure/account/accountStore', () => ({
-  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+  useAccountStore: (selector: (s: MockAccountState) => unknown) =>
     selector(mockAccountState),
 }));
 
@@ -59,7 +64,7 @@ describe('ProfileEditPage – no-account handling', () => {
 
   it('ne redirige pas quand un compte existe', async () => {
     mockAccountState = {
-      accounts: [{ id: 1 } as any],
+      accounts: [{ id: 1 }],
       activeAccountId: 1,
     };
 

--- a/frontend/src/tests/noAccount_ProfilePage.test.tsx
+++ b/frontend/src/tests/noAccount_ProfilePage.test.tsx
@@ -17,14 +17,19 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+type MockAccountState = {
+  accounts: { id: number }[];
+  activeAccountId: number | null;
+};
+
 // 2) Mock account store
-let mockAccountState = {
-  accounts: [] as { id: number }[],
-  activeAccountId: null as number | null,
+let mockAccountState: MockAccountState = {
+  accounts: [],
+  activeAccountId: null,
 };
 
 vi.mock('../infrastructure/account/accountStore', () => ({
-  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+  useAccountStore: (selector: (s: MockAccountState) => unknown) =>
     selector(mockAccountState),
 }));
 
@@ -59,7 +64,7 @@ describe('ProfilePage – no-account handling', () => {
 
   it('ne redirige pas quand un compte existe', async () => {
     mockAccountState = {
-      accounts: [{ id: 1 } as any],
+      accounts: [{ id: 1 }],
       activeAccountId: 1,
     };
 

--- a/frontend/src/tests/noAccount_ProfilePage.test.tsx
+++ b/frontend/src/tests/noAccount_ProfilePage.test.tsx
@@ -1,0 +1,73 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 1) Mock router
+const mockNavigate = vi.fn();
+let mockLocation = { pathname: '/profile' };
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
+  };
+});
+
+// 2) Mock account store
+let mockAccountState = {
+  accounts: [] as { id: number }[],
+  activeAccountId: null as number | null,
+};
+
+vi.mock('../infrastructure/account/accountStore', () => ({
+  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+    selector(mockAccountState),
+}));
+
+// ⬇️ 3) Mock useAuth avec LE BON CHEMIN depuis /src/tests
+vi.mock('../app/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { email: 'test@example.com' },
+  }),
+}));
+
+// 4) Ensuite seulement on importe ProfilePage
+import ProfilePage from '../interface/pages/Profile/ProfilePage';
+
+describe('ProfilePage – no-account handling', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockAccountState = { accounts: [], activeAccountId: null };
+    mockLocation = { pathname: '/profile' };
+  });
+
+  it('redirige vers onboarding quand aucun compte', async () => {
+    mockAccountState = { accounts: [], activeAccountId: null };
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/onboarding-account', {
+        replace: true,
+      });
+    });
+  });
+
+  it('ne redirige pas quand un compte existe', async () => {
+    mockAccountState = {
+      accounts: [{ id: 1 } as any],
+      activeAccountId: 1,
+    };
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      const calls = mockNavigate.mock.calls.map(([path]) => path);
+      expect(calls).not.toContain('/onboarding-account');
+    });
+  });
+});

--- a/frontend/src/tests/useRequireAccount.test.tsx
+++ b/frontend/src/tests/useRequireAccount.test.tsx
@@ -26,7 +26,7 @@ let mockAccountState: {
 
 // mock useAccountStore
 vi.mock('../infrastructure/account/accountStore', () => ({
-  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+  useAccountStore: (selector: (s: typeof mockAccountState) => unknown) =>
     selector(mockAccountState),
 }));
 

--- a/frontend/src/tests/useRequireAccount.test.tsx
+++ b/frontend/src/tests/useRequireAccount.test.tsx
@@ -1,0 +1,108 @@
+// src/tests/useRequireAccount.test.tsx
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRequireAccount } from '../interface/hooks/useRequireAccount';
+
+// mock navigate
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/test' }), // n'importe quel path
+  };
+});
+
+// state mockable pour le store
+let mockAccountState: {
+  accounts: { id: number }[];
+  activeAccountId: number | null;
+};
+
+// mock useAccountStore
+vi.mock('../infrastructure/account/accountStore', () => ({
+  useAccountStore: (selector: (s: typeof mockAccountState) => any) =>
+    selector(mockAccountState),
+}));
+
+function TestComponent(props: {
+  loading?: boolean;
+  enabled?: boolean;
+  redirectTo?: string;
+}) {
+  useRequireAccount(props);
+  return null;
+}
+
+describe('useRequireAccount', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockAccountState = {
+      accounts: [],
+      activeAccountId: null,
+    };
+  });
+
+  it('redirige quand aucun compte et loading = false', () => {
+    mockAccountState.accounts = [];
+    mockAccountState.activeAccountId = null;
+
+    render(<TestComponent loading={false} />);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/onboarding-account', {
+      replace: true,
+    });
+  });
+
+  it('ne redirige pas pendant le chargement', () => {
+    mockAccountState.accounts = [];
+    mockAccountState.activeAccountId = null;
+
+    render(<TestComponent loading={true} />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('ne redirige pas quand un compte existe dans la liste', () => {
+    mockAccountState.accounts = [{ id: 1 }];
+    mockAccountState.activeAccountId = null;
+
+    render(<TestComponent loading={false} />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('ne redirige pas quand activeAccountId est défini', () => {
+    mockAccountState.accounts = [];
+    mockAccountState.activeAccountId = 123;
+
+    render(<TestComponent loading={false} />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('ne fait rien quand enabled = false', () => {
+    mockAccountState.accounts = [];
+    mockAccountState.activeAccountId = null;
+
+    render(<TestComponent loading={false} enabled={false} />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('utilise redirectTo personnalisé', () => {
+    mockAccountState.accounts = [];
+    mockAccountState.activeAccountId = null;
+
+    render(<TestComponent loading={false} redirectTo="/custom-onboarding" />);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/custom-onboarding', {
+      replace: true,
+    });
+  });
+});

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "src/tests/**/*"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,12 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/tests/**/*.test.ts'],
+    include: ['src/tests/**/*.test.ts', 'src/tests/**/*.test.tsx'],
     environment: 'jsdom',
-    globals: true,           // pour pouvoir utiliser `describe`, `it`, `expect` sans import
+    globals: true, // pour pouvoir utiliser `describe`, `it`, `expect` sans import
     coverage: {
-      reporter: ['text', 'lcov'],  // affichage console + rapport HTML
-      exclude: ['node_modules/', 'src/interface/**'],  // modules et UI si tu veux
+      reporter: ['text', 'lcov'], // affichage console + rapport HTML
+      exclude: ['node_modules/', 'src/interface/**'], // modules et UI si tu veux
     },
   },
 });


### PR DESCRIPTION
## Summary

- Implement `useRequireAccount` hook to enforce account existence on protected pages
- Auto-redirect to `/onboarding-account` when no account available
- Add onboarding CTA cards on Dashboard and Quote List for users without accounts
- Fix TypeScript build errors (test files JSX config)

## Changes

### New Features
- **useRequireAccount hook** (`src/interface/hooks/useRequireAccount.ts`):
  - Redirects to onboarding when `accounts = []` && `activeAccountId = null`
  - Respects `loading` state to avoid premature redirects
  - Configurable `redirectTo` and `enabled` options
  - Full test coverage (6 scenarios)

- **Onboarding CTAs**:
  - Dashboard: Show CTA card when `activeAccountId === null`
  - Quote List: Same CTA to drive account creation

### Pages Updated
- `ProfilePage.tsx`: Apply `useRequireAccount` hook
- `ProfileEditPage.tsx`: Replace manual redirect logic with hook
- `QuoteCreatePage.tsx`: Add account requirement check
- `QuoteEditPage.tsx`: Add account requirement check

### Bug Fixes
- **tsconfig.node.json**: Remove `src/tests/**/*` from include (was causing JSX errors)
- ESLint config: Add `projectService` and `tsconfigRootDir` for proper TS integration

### Tests
- `useRequireAccount.test.tsx`: 6 test scenarios (redirect, loading, existing account, disabled, custom redirect)
- `noAccount_ProfilePage.test.tsx`: Integration tests for ProfilePage
- `noAccount_ProfileEditPage.test.tsx`: Integration tests for ProfileEditPage
- BDD spec: `docs/tests/use_require_account.feature.md`

## Test Plan

- [x] Build passes (`pnpm run build`)
- [x] Type check passes
- [x] All tests pass
- [x] Manual testing: Visit profile/quotes without account → redirects to onboarding
- [x] Manual testing: Dashboard shows CTA when no account

@Bertrand2808