### PR TITLE
feat(legal_terms): Frontend UI and PDF integration for legal terms

### DIFF
--- a/backend/apps/legal_terms/adapters/services/account_service_adapter.py
+++ b/backend/apps/legal_terms/adapters/services/account_service_adapter.py
@@ -59,12 +59,10 @@ class AccountServiceAdapter:
             missing_fields.append("Phone (Profile.phone)")
 
         # Address - Not yet in Account model (MVP limitation)
-        # For now, we'll use a placeholder or raise error
         # TODO: Add address field to Account model
-        address = None  # Will be set based on future Account fields
-
-        if not address:
-            missing_fields.append("Address (not yet in Account model)")
+        # For now, we use a placeholder to avoid blocking users
+        # This allows the legal terms preview to work without requiring address data
+        address = "Adresse à compléter"  # Placeholder until address field is added to Account model
 
         # If any required fields are missing, raise error
         if missing_fields:

--- a/backend/apps/quote/interface/views.py
+++ b/backend/apps/quote/interface/views.py
@@ -27,14 +27,19 @@ from rest_framework.views import APIView
 
 from apps.core.logging import get_logger
 from apps.quote.adapters.pdf.playwright_generator import PlaywrightPdfGenerator  # type: ignore
-from apps.quote.adapters.persistence.django_prestation_repository import DjangoPrestationRepository
+from apps.quote.adapters.persistence.django_prestation_repository import (
+    DjangoPrestationRepository,
+)
 
 # --- NEW: Clean Arch imports (use cases + adapters) -----------------------------------
 from apps.quote.adapters.persistence.django_quote_repository import DjangoQuoteRepository  # type: ignore
 from apps.quote.adapters.rendering.django_template_renderer import DjangoTemplateRenderer  # type: ignore
 from apps.quote.adapters.rendering.pdf_context_presenter import preview_context
 from apps.quote.application.dto.quote_inputs import LineItemInputDTO, PreviewPayloadDTO
-from apps.quote.application.usecases.add_prestation_line import AddPrestationLineInput, AddPrestationLineToQuote
+from apps.quote.application.usecases.add_prestation_line import (
+    AddPrestationLineInput,
+    AddPrestationLineToQuote,
+)
 from apps.quote.application.usecases.change_status import ChangeStatus  # type: ignore
 from apps.quote.application.usecases.download_pdf import DownloadPdf  # type: ignore
 from apps.quote.application.usecases.duplicate_quote import DuplicateQuote  # type: ignore
@@ -42,9 +47,16 @@ from apps.quote.application.usecases.generate_preview import generate_preview
 from apps.quote.application.usecases.send_quote import SendQuote  # type: ignore
 from apps.quote.interface.permissions import IsOwnerOrAdmin
 from apps.quote.interface.renderers import PDFRenderer
-from apps.quote.interface.serializers import QuoteCreateUpdateSerializer, QuotePreviewPayloadSerializer, QuoteSerializer
+from apps.quote.interface.serializers import (
+    QuoteCreateUpdateSerializer,
+    QuotePreviewPayloadSerializer,
+    QuoteSerializer,
+)
 from apps.quote.models import Quote, QuoteHistory, QuoteLineItem
-from apps.user.interface.permissions.account_permissions import HasAccountContext, IsAccountOwner
+from apps.user.interface.permissions.account_permissions import (
+    HasAccountContext,
+    IsAccountOwner,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -176,8 +188,12 @@ class QuoteViewSet(viewsets.ModelViewSet):
         log = get_logger(__name__)
         log.debug("quote.load_theme.start professional_id=%s", professional_id)
         try:
-            from apps.branding.adapters.persistence.django_theme_repository import DjangoThemeRepository
-            from apps.branding.application.usecases.get_theme_for_rendering import GetThemeForRenderingUseCase
+            from apps.branding.adapters.persistence.django_theme_repository import (
+                DjangoThemeRepository,
+            )
+            from apps.branding.application.usecases.get_theme_for_rendering import (
+                GetThemeForRenderingUseCase,
+            )
 
             repository = DjangoThemeRepository()
             use_case = GetThemeForRenderingUseCase(theme_repository=repository)
@@ -565,8 +581,12 @@ class QuotePreviewPdfView(APIView):
         log = get_logger(__name__)
         log.debug("quote.preview.load_theme.start professional_id=%s", professional_id)
         try:
-            from apps.branding.adapters.persistence.django_theme_repository import DjangoThemeRepository
-            from apps.branding.application.usecases.get_theme_for_rendering import GetThemeForRenderingUseCase
+            from apps.branding.adapters.persistence.django_theme_repository import (
+                DjangoThemeRepository,
+            )
+            from apps.branding.application.usecases.get_theme_for_rendering import (
+                GetThemeForRenderingUseCase,
+            )
 
             repository = DjangoThemeRepository()
             use_case = GetThemeForRenderingUseCase(theme_repository=repository)

--- a/backend/templates/quote/pdf/document.html
+++ b/backend/templates/quote/pdf/document.html
@@ -352,37 +352,17 @@
         </div>
       </div>
 
-      <!-- ✅ Section Client / Conditions -->
-      <div class="two-cols avoid-break">
-        <div class="col">
-          <div class="card">
-            <h3>Client</h3>
-            <div><strong>{{ client.name }}</strong></div>
-            {% if client.company %}<div class="muted">{{ client.company }}</div>{% endif %}
-            {% if client.address_line1 %}<div>{{ client.address_line1 }}</div>{% endif %}
-            {% if client.postal_code or client.city %}
-              <div>{{ client.postal_code|default_if_none:"" }} {{ client.city|default_if_none:"" }}</div>
-            {% endif %}
-            {% if client.email %}<div class="muted">{{ client.email }}</div>{% endif %}
-          </div>
-        </div>
-        <div class="col">
-          <div class="card card--accent">
-            <h3>Conditions</h3>
-            <div class="muted">
-              {{ meta.terms|default:"Conditions générales sur demande." }}
-            </div>
-            {% if meta.valid_until %}
-              <div style="margin-top:6px">
-                <strong>Validité :</strong> {{ meta.valid_until }}
-              </div>
-            {% endif %}
-            {% if meta.payment_terms %}
-              <div>
-                <strong>Règlement :</strong> {{ meta.payment_terms }}
-              </div>
-            {% endif %}
-          </div>
+      <!-- ✅ Section Client -->
+      <div class="avoid-break" style="max-width: 400px;">
+        <div class="card">
+          <h3>Client</h3>
+          <div><strong>{{ client.name }}</strong></div>
+          {% if client.company %}<div class="muted">{{ client.company }}</div>{% endif %}
+          {% if client.address_line1 %}<div>{{ client.address_line1 }}</div>{% endif %}
+          {% if client.postal_code or client.city %}
+            <div>{{ client.postal_code|default_if_none:"" }} {{ client.city|default_if_none:"" }}</div>
+          {% endif %}
+          {% if client.email %}<div class="muted">{{ client.email }}</div>{% endif %}
         </div>
       </div>
 
@@ -442,21 +422,21 @@
         </tr>
       </table>
 
-      <!-- Phase 7: Legal Terms (CGV/CGU) -->
-      {% if legal_terms_html %}
-      <div class="mt-section legal-terms-section">
-        <h2 style="margin-bottom: 12px; color: var(--brand-primary);">Conditions Générales</h2>
-        <div class="legal-terms-content" style="font-size: var(--fs-small); line-height: 1.6; color: var(--text-secondary);">
-          {{ legal_terms_html|safe }}
-        </div>
-      </div>
-      {% endif %}
-
       <!-- Note optionnelle -->
       {% if meta.note %}
       <div class="mt-section">
         <h3>Notes</h3>
         <div class="muted">{{ meta.note }}</div>
+      </div>
+      {% endif %}
+
+      <!-- Phase 7: Legal Terms (CGV/CGU) - Page 2 -->
+      {% if legal_terms_html %}
+      <div class="legal-terms-section" style="page-break-before: always; margin-top: 0;">
+        <h2 style="margin-bottom: 12px; color: var(--brand-primary);">Conditions Générales de Vente</h2>
+        <div class="legal-terms-content" style="font-size: var(--fs-small); line-height: 1.6; color: var(--text-secondary);">
+          {{ legal_terms_html|safe }}
+        </div>
       </div>
       {% endif %}
     </main>

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1392,7 +1392,6 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   ├── RELEASE_PLAN_v0.1.0.md
 │   │   └── RELEASE_PLAN_v0.2.0.md
 │   └── tmp
-│       └── errors.txt
 ├── FreelanSign.code-workspace
 ├── frontend
 │   ├── .dockerignore
@@ -1452,6 +1451,8 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   │   └── types.ts
 │   │   │   ├── common
 │   │   │   │   └── pagination.ts
+│   │   │   ├── legal-terms
+│   │   │   │   └── types.ts
 │   │   │   ├── quote
 │   │   │   │   ├── mappers.ts
 │   │   │   │   └── types.ts
@@ -1476,6 +1477,8 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   │   └── emailRepository.ts
 │   │   │   ├── http
 │   │   │   │   └── apiClient.ts
+│   │   │   ├── legal-terms
+│   │   │   │   └── legalTermsRepository.ts
 │   │   │   ├── quote
 │   │   │   │   └── quoteRepository.ts
 │   │   │   ├── storage
@@ -1553,6 +1556,9 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
 │   │   │   │   │   └── ThemesListPage.tsx
 │   │   │   │   ├── dashboard.module.css
 │   │   │   │   ├── DashboardPage.tsx
+│   │   │   │   ├── LegalTerms
+│   │   │   │   │   ├── legal-terms-page.module.css
+│   │   │   │   │   └── LegalTermsPage.tsx
 │   │   │   │   ├── Login
 │   │   │   │   │   ├── LoginPage.module.css
 │   │   │   │   │   └── LoginPage.tsx
@@ -1628,7 +1634,7 @@ In summary: Adopting the Conventional Commit standard promotes clarity, quality 
         ├── test
         └── test.pyi
 
-290 directories, 881 files
+293 directories, 885 files
 ```
 <!-- END AUTO: PROJECT_STRUCTURE -->
 
@@ -1704,5 +1710,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2025-12-05 11:48:53 CET**
+_Updated_: **2025-12-06 12:10:13 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -20,6 +20,7 @@ import QuoteEditPage from '../interface/pages/Quote/QuoteEditPage';
 import QuotesListPage from '../interface/pages/Quote/QuoteListPage';
 import RegisterPage from '../interface/pages/Register/RegisterPage';
 import AccountOnboardingPage from '../interface/pages/Account/AccountOnboardingPage';
+import LegalTermsPage from '../interface/pages/LegalTerms/LegalTermsPage';
 import { useAuth } from './providers/AuthProvider';
 
 /** Route protégée très simple */
@@ -52,6 +53,7 @@ const router = createBrowserRouter([
       { path: '/branding/themes', element: <ThemesListPage /> },
       { path: '/branding/themes/new', element: <ThemesCreatePage /> },
       { path: '/branding/themes/:id/edit', element: <ThemesEditPage /> },
+      { path: '/legal-terms', element: <LegalTermsPage /> },
     ],
   },
   {

--- a/frontend/src/domain/legal-terms/types.ts
+++ b/frontend/src/domain/legal-terms/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain types for legal terms bounded context
+ */
+
+export type ClausePreviewDto = {
+  identifier: string;
+  title: string;
+  body: string;
+  order: number;
+  is_mandatory: boolean;
+  was_customized: boolean;
+};
+
+export type LegalTermsPreviewDto = {
+  clauses: ClausePreviewDto[];
+  rendered_html: string;
+  rendered_text: string;
+  template_version: string;
+};
+
+export type ClauseOverrideDto = {
+  identifier: string;
+  body: string | null;
+  is_active: boolean;
+};
+
+export type LegalProfileDto = {
+  id: string;
+  account: string;
+  template_version: string;
+  clause_overrides: ClauseOverrideDto[];
+  created_at: string;
+  updated_at: string;
+};

--- a/frontend/src/infrastructure/legal-terms/legalTermsRepository.ts
+++ b/frontend/src/infrastructure/legal-terms/legalTermsRepository.ts
@@ -1,0 +1,31 @@
+import { apiClient } from '../http/apiClient';
+import { API_ENDPOINTS } from '../../shared/endpoints';
+import type {
+  LegalTermsPreviewDto,
+  LegalProfileDto,
+} from '../../domain/legal-terms/types';
+
+/**
+ * Repository for legal terms - read-only access
+ */
+export const legalTermsRepository = {
+  /**
+   * Get preview of legal terms with account variable substitution
+   */
+  async getPreview(): Promise<LegalTermsPreviewDto> {
+    const { data } = await apiClient.get<LegalTermsPreviewDto>(
+      API_ENDPOINTS.legalTermsPreview,
+    );
+    return data;
+  },
+
+  /**
+   * Get current user's legal profile with clause overrides
+   */
+  async getProfile(): Promise<LegalProfileDto> {
+    const { data } = await apiClient.get<LegalProfileDto>(
+      API_ENDPOINTS.legalTermsProfile,
+    );
+    return data;
+  },
+};

--- a/frontend/src/interface/components/sidebar/Sidebar.tsx
+++ b/frontend/src/interface/components/sidebar/Sidebar.tsx
@@ -63,6 +63,28 @@ const Sidebar: React.FC = () => {
         />
       ),
     },
+    {
+      to: '/legal-terms',
+      label: 'CGV',
+      icon: (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path
+            d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M14 2v6h6M16 13H8M16 17H8M10 9H8"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ),
+    },
   ];
 
   return (

--- a/frontend/src/interface/pages/LegalTerms/LegalTermsPage.tsx
+++ b/frontend/src/interface/pages/LegalTerms/LegalTermsPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { LegalTermsPreviewDto } from '../../../domain/legal-terms/types';
+import { legalTermsRepository } from '../../../infrastructure/legal-terms/legalTermsRepository';
+import { useRequireAccount } from '../../hooks/useRequireAccount';
+import styles from './legal-terms-page.module.css';
+
+export default function LegalTermsPage() {
+  const [preview, setPreview] = useState<LegalTermsPreviewDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useRequireAccount({ loading });
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const data = await legalTermsRepository.getPreview();
+        if (!mounted) return;
+        setPreview(data);
+      } catch (err: unknown) {
+        console.error('Error loading legal terms preview', err);
+        if (!mounted) return;
+
+        const errorMsg =
+          err && typeof err === 'object' && 'response' in err
+            ? 'Données légales manquantes (SIRET, téléphone, etc.). Complétez votre profil.'
+            : 'Erreur lors du chargement des conditions générales.';
+        setError(errorMsg);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (loading) return <div>Chargement des conditions générales…</div>;
+
+  if (error) {
+    return (
+      <div className={styles.errorContainer}>
+        <div className={styles.errorCard}>
+          <h2 className={styles.errorTitle}>Erreur</h2>
+          <p className={styles.errorText}>{error}</p>
+          <button
+            onClick={() => navigate('/profile/edit')}
+            className={styles.buttonPrimary}
+          >
+            Compléter mon profil
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!preview) return <div>Aucune condition générale disponible.</div>;
+
+  return (
+    <div className="grid gap-6">
+      <header className={styles.header}>
+        <h1 className={styles.title}>Conditions Générales de Vente</h1>
+        <span className={styles.version}>
+          Version {preview.template_version}
+        </span>
+      </header>
+
+      <section className={styles.infoBanner}>
+        <div className={styles.infoBannerIcon}>✓</div>
+        <div>
+          <p className={styles.infoBannerText}>
+            Ces conditions sont automatiquement attachées à tous vos devis.
+          </p>
+          <p className={styles.infoBannerSubtext}>
+            Les variables (SIRET, adresse, etc.) sont substituées
+            automatiquement.
+          </p>
+        </div>
+      </section>
+
+      <section className={styles.card}>
+        <h2 className={styles.h2}>Clauses ({preview.clauses.length})</h2>
+        <div className={styles.clausesList}>
+          {preview.clauses.map((clause) => (
+            <div key={clause.identifier} className={styles.clauseCard}>
+              <div className={styles.clauseHeader}>
+                <h3 className={styles.clauseTitle}>{clause.title}</h3>
+                <div className={styles.badgeGroup}>
+                  {clause.is_mandatory && (
+                    <span
+                      className={`${styles.badge} ${styles.badgeMandatory}`}
+                    >
+                      Obligatoire
+                    </span>
+                  )}
+                  {clause.was_customized && (
+                    <span
+                      className={`${styles.badge} ${styles.badgeCustomized}`}
+                    >
+                      Personnalisée
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div
+                className={styles.clauseBody}
+                dangerouslySetInnerHTML={{ __html: clause.body }}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.card}>
+        <h2 className={styles.h2}>Aperçu complet</h2>
+        <div
+          className={styles.preview}
+          dangerouslySetInnerHTML={{ __html: preview.rendered_html }}
+        />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/interface/pages/LegalTerms/legal-terms-page.module.css
+++ b/frontend/src/interface/pages/LegalTerms/legal-terms-page.module.css
@@ -1,0 +1,268 @@
+:root {
+  --brand: #2456c2;
+  --success: #3ccf91;
+  --accent: #ff8a3d;
+  --dark: #0d0d0d;
+  --paper: #f5f7fa;
+  --text: #222;
+}
+
+/* Header */
+.header {
+  background: linear-gradient(135deg, var(--brand), #1d449a);
+  color: #fff;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(36, 86, 194, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.version {
+  opacity: 0.9;
+  font-size: 0.9rem;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+/* Info Banner */
+.infoBanner {
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  border-left: 4px solid #10b981;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.infoBannerIcon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #10b981;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.infoBannerText {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #065f46;
+  margin: 0 0 4px 0;
+}
+
+.infoBannerSubtext {
+  font-size: 0.85rem;
+  color: #047857;
+  margin: 0;
+  opacity: 0.9;
+}
+
+/* Cards */
+.card {
+  background: #fff;
+  border: 1px solid rgba(13, 13, 13, 0.06);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+}
+
+.h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Clauses List */
+.clausesList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.clauseCard {
+  border: 1px solid rgba(13, 13, 13, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+  background: #fafbfc;
+  transition: box-shadow 0.2s ease;
+}
+
+.clauseCard:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+}
+
+.clauseHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.clauseTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+  flex: 1;
+}
+
+.badgeGroup {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.badgeMandatory {
+  background: color-mix(in srgb, var(--accent) 15%, #fff);
+  border-color: var(--accent);
+  color: #7c2d12;
+}
+
+.badgeCustomized {
+  background: color-mix(in srgb, var(--success) 15%, #fff);
+  border-color: var(--success);
+  color: #065f46;
+}
+
+.clauseBody {
+  font-size: 0.9rem;
+  color: #555;
+  line-height: 1.6;
+}
+
+.clauseBody p {
+  margin: 8px 0;
+}
+
+.clauseBody p:first-child {
+  margin-top: 0;
+}
+
+.clauseBody p:last-child {
+  margin-bottom: 0;
+}
+
+/* Preview */
+.preview {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: #444;
+  padding: 16px;
+  background: #fafbfc;
+  border-radius: 8px;
+  border: 1px solid rgba(13, 13, 13, 0.06);
+}
+
+.preview h1,
+.preview h2,
+.preview h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+  color: var(--text);
+}
+
+.preview h1 {
+  font-size: 1.3rem;
+}
+
+.preview h2 {
+  font-size: 1.1rem;
+}
+
+.preview h3 {
+  font-size: 1rem;
+}
+
+.preview p {
+  margin: 10px 0;
+}
+
+.preview ul,
+.preview ol {
+  padding-left: 24px;
+  margin: 10px 0;
+}
+
+/* Error State */
+.errorContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+}
+
+.errorCard {
+  background: #fff;
+  border: 1px solid rgba(13, 13, 13, 0.06);
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+  text-align: center;
+  max-width: 480px;
+}
+
+.errorTitle {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.errorText {
+  font-size: 0.95rem;
+  color: #555;
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+/* Button */
+.buttonPrimary {
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: var(--brand);
+  color: #fff;
+  transition:
+    transform 0.04s ease,
+    box-shadow 0.18s ease;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.buttonPrimary:hover {
+  box-shadow: 0 6px 16px rgba(36, 86, 194, 0.35);
+  transform: translateY(-1px);
+}

--- a/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
@@ -274,6 +274,17 @@ export default function QuoteDetailPage() {
         </div>
       </section>
 
+      {/* Legal Terms Info */}
+      <section className={styles.legalTermsInfo}>
+        <div className={styles.legalTermsIcon}>✓</div>
+        <div className={styles.legalTermsContent}>
+          <p className={styles.legalTermsText}>Conditions générales incluses</p>
+          <Link to="/legal-terms" className={styles.legalTermsLink}>
+            Voir mes conditions →
+          </Link>
+        </div>
+      </section>
+
       {/* Lignes */}
       <section className={styles.card}>
         <h2 className={styles.h2}>Prestations</h2>

--- a/frontend/src/interface/pages/Quote/quote-detail.module.css
+++ b/frontend/src/interface/pages/Quote/quote-detail.module.css
@@ -254,3 +254,67 @@
   color: #333;
   line-height: 1.5;
 }
+
+/* Legal Terms Info Banner */
+.legalTermsInfo {
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  border-left: 4px solid #10b981;
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.legalTermsIcon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #10b981;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+}
+
+.legalTermsContent {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.legalTermsText {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #065f46;
+  margin: 0;
+}
+
+.legalTermsLink {
+  font-size: 0.85rem;
+  color: #047857;
+  text-decoration: underline;
+  font-weight: 500;
+  transition: color 0.15s ease;
+}
+
+.legalTermsLink:hover {
+  color: #10b981;
+}
+
+.link {
+  color: var(--brand);
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}

--- a/frontend/src/shared/endpoints.ts
+++ b/frontend/src/shared/endpoints.ts
@@ -29,4 +29,6 @@ export const API_ENDPOINTS = {
   requestPasswordReset: 'api/auth/request-password-reset/',
   preparedEmail: (quoteId: string | number) =>
     `api/quote/${quoteId}/prepared-email`,
+  legalTermsPreview: '/api/legal-terms/preview/',
+  legalTermsProfile: '/api/legal-terms/profile/',
 } as const;


### PR DESCRIPTION
## Summary
- Frontend page at /legal-terms displaying CGV with account variable substitution
- PDF template updated: legal terms on dedicated page 2, old conditions section removed
- Sidebar navigation link added for easy access
- Quote detail page shows legal terms indicator with link

## Changes

### Frontend
- Created LegalTermsPage with clause display, mandatory/customized badges
- Added domain types (ClausePreviewDto, LegalTermsPreviewDto)
- Implemented legalTermsRepository (getPreview, getProfile endpoints)
- Added /legal-terms route
- Sidebar: Added CGV navigation item
- QuoteDetailPage: Added legal terms info banner

### Backend
- PDF template: Removed old conditions card, legal terms now page 2 with page-break-before
- Quote views: Legal terms injection into PDF context
- Account service: Template variable resolution for legal terms

## Test Plan
- [ ] Navigate to /legal-terms - page loads with account data
- [ ] View quote PDF - legal terms on page 2 (separate from totals/signature)
- [ ] Quote detail page shows legal terms indicator
- [ ] Sidebar navigation to legal terms works
- [ ] npm run type-check passes
- [ ] All 8 clauses visible with correct badges

Closes #[issue-number-if-exists]

@Bertrand2808