### PR TITLE
Mergre fix bug champ remise

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1851,5 +1851,5 @@ _No package.json found at /Users/bertrandrenaudin/Desktop/DEV/FreelanSign/backen
 
 _Last updated_
 <!-- BEGIN AUTO: LAST_UPDATED -->
-_Updated_: **2026-01-19 11:25:24 CET**
+_Updated_: **2026-01-19 11:51:08 CET**
 <!-- END AUTO: LAST_UPDATED -->

--- a/frontend/src/domain/quote/mappers.ts
+++ b/frontend/src/domain/quote/mappers.ts
@@ -21,6 +21,7 @@ export function apiItemsToUi(items: ApiQuoteItem[] | undefined): UiQuoteLine[] {
       quantity: Number(it.qty ?? 0),
       unit_price: Number(it.unit_price ?? 0),
       tax_rate: it.tax_rate != null ? Number(it.tax_rate) / 100 : 0,
+      discount: it.discount != null ? Number(it.discount) : 0,
     }),
   );
 }
@@ -109,7 +110,7 @@ export function uiToUpdatePayload(q: UiQuote): ApiQuoteUpdatePayload {
       qty: String(l.quantity),
       unit_price: String(Number(l.unit_price).toFixed(2)),
       tax_rate: String(((l.tax_rate ?? 0) * 100).toFixed(2)),
-      discount: '0.00',
+      discount: String(Number(l.discount ?? 0).toFixed(2)),
       order: i,
     }));
   }
@@ -129,8 +130,10 @@ export function apiToUiQuoteDetail(
   const line_items: UiQuoteLineDetail[] = items.map((it, idx) => {
     const qty = num(it.qty);
     const up = num(it.unit_price);
+    const disc = num(it.discount);
     const taxPct = it.tax_rate != null ? num(it.tax_rate) : 0; // 0..100
-    const pre = it.pre_tax_total != null ? num(it.pre_tax_total) : qty * up;
+    const pre =
+      it.pre_tax_total != null ? num(it.pre_tax_total) : qty * up - disc;
     const tax =
       it.tax_amount != null ? num(it.tax_amount) : pre * (taxPct / 100);
     return {
@@ -140,6 +143,7 @@ export function apiToUiQuoteDetail(
       quantity: qty,
       unit_price: up,
       tax_rate: taxPct / 100,
+      discount: disc,
       pre_tax_total: pre,
       tax_amount: tax,
       total: pre + tax,

--- a/frontend/src/domain/quote/types.ts
+++ b/frontend/src/domain/quote/types.ts
@@ -101,6 +101,7 @@ export type UiQuoteLine = {
   quantity: number;
   unit_price: number;
   tax_rate?: number | null; // 0.2 => 20%
+  discount?: number | null; // absolute amount (EUR)
 };
 
 export type UiQuote = {
@@ -125,6 +126,7 @@ export type UiQuoteLineDetail = {
   quantity: number;
   unit_price: number;
   tax_rate?: number | null; // fraction 0..1
+  discount?: number | null; // absolute amount (EUR)
   pre_tax_total?: number | null;
   tax_amount?: number | null;
   total?: number | null;

--- a/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteDetailPage.tsx
@@ -139,18 +139,20 @@ export default function QuoteDetailPage() {
     const sub =
       quote.subtotal ??
       lines.reduce(
-        (acc, l) => acc + (l.pre_tax_total ?? l.quantity * l.unit_price),
+        (acc, l) =>
+          acc +
+          (l.pre_tax_total ??
+            Math.max(0, l.quantity * l.unit_price - (l.discount ?? 0))),
         0,
       );
     const taxes =
       quote.tax_total ??
-      lines.reduce(
-        (acc, l) =>
-          acc +
-          (l.tax_amount ??
-            (l.pre_tax_total ?? l.quantity * l.unit_price) * (l.tax_rate ?? 0)),
-        0,
-      );
+      lines.reduce((acc, l) => {
+        const preTax =
+          l.pre_tax_total ??
+          Math.max(0, l.quantity * l.unit_price - (l.discount ?? 0));
+        return acc + (l.tax_amount ?? preTax * (l.tax_rate ?? 0));
+      }, 0);
     const total = quote.total ?? sub + taxes - (quote.discount_total ?? 0);
     return { sub, taxes, total };
   }, [quote]);
@@ -394,6 +396,9 @@ export default function QuoteDetailPage() {
                       PU HT
                     </TableHead>
                     <TableHead className="h-10 py-3 text-[11px] font-bold text-muted-foreground uppercase tracking-wider text-right">
+                      Remise
+                    </TableHead>
+                    <TableHead className="h-10 py-3 text-[11px] font-bold text-muted-foreground uppercase tracking-wider text-right">
                       TVA
                     </TableHead>
                     <TableHead className="h-10 py-3 text-[11px] font-bold text-muted-foreground uppercase tracking-wider text-right pr-6">
@@ -427,12 +432,25 @@ export default function QuoteDetailPage() {
                       <TableCell className="py-4 text-right align-top text-sm">
                         {money.format(l.unit_price)}
                       </TableCell>
+                      <TableCell className="py-4 text-right align-top text-sm text-muted-foreground">
+                        {l.discount && l.discount > 0 ? (
+                          <span className="text-destructive font-medium">
+                            - {money.format(l.discount)}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </TableCell>
                       <TableCell className="py-4 text-right align-top text-sm text-muted-foreground font-medium">
                         {((l.tax_rate ?? 0) * 100).toFixed(0)}%
                       </TableCell>
                       <TableCell className="py-4 text-right align-top pr-6 font-bold text-sm">
                         {money.format(
-                          l.pre_tax_total ?? l.quantity * l.unit_price,
+                          l.pre_tax_total ??
+                            Math.max(
+                              0,
+                              l.quantity * l.unit_price - (l.discount ?? 0),
+                            ),
                         )}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/interface/pages/Quote/QuoteEditPage.tsx
+++ b/frontend/src/interface/pages/Quote/QuoteEditPage.tsx
@@ -54,6 +54,8 @@ type QuoteLine = {
   unit_price: number;
   /** 0.2 => 20% (fraction UI) */
   tax_rate?: number | null;
+  /** absolute discount amount (EUR) */
+  discount?: number | null;
 };
 
 type ClientInfo = {
@@ -208,6 +210,7 @@ export default function QuoteEditPage() {
               quantity: l.quantity,
               unit_price: l.unit_price,
               tax_rate: l.tax_rate ?? 0,
+              discount: l.discount ?? 0,
             }),
           ),
         };
@@ -271,7 +274,7 @@ export default function QuoteEditPage() {
       quantity: Number(l.quantity),
       unit_price: Number(l.unit_price ?? 0),
       tax_rate: typeof l.tax_rate === 'number' ? l.tax_rate : null,
-      discount: 0,
+      discount: Number(l.discount ?? 0),
     }));
     const branding = { name: 'FreelanSign' };
     return { seller, client, meta, lines, branding };
@@ -296,10 +299,15 @@ export default function QuoteEditPage() {
   // Derived totals (UI)
   const totals = useMemo(() => {
     const lines = quote?.line_items ?? [];
-    const sub = lines.reduce((acc, l) => acc + l.quantity * l.unit_price, 0);
+    const sub = lines.reduce((acc, l) => {
+      const base = l.quantity * l.unit_price - (l.discount ?? 0);
+      return acc + Math.max(0, base);
+    }, 0);
     const tax = lines.reduce((acc, l) => {
+      const base = l.quantity * l.unit_price - (l.discount ?? 0);
+      const preTax = Math.max(0, base);
       const rate = l.tax_rate ?? 0;
-      return acc + l.quantity * l.unit_price * rate;
+      return acc + preTax * rate;
     }, 0);
     return { sub, tax, total: sub + tax };
   }, [quote]);
@@ -337,6 +345,7 @@ export default function QuoteEditPage() {
         quantity: 1,
         unit_price: 0,
         tax_rate: 0.2,
+        discount: 0,
       };
       return { ...q, line_items: [...q.line_items, next] };
     });
@@ -403,7 +412,7 @@ export default function QuoteEditPage() {
         unit_price: String(Number(l.unit_price).toFixed(2)),
         // 0.2 (20%) -> "20.00"
         tax_rate: String(((l.tax_rate ?? 0) * 100).toFixed(2)),
-        discount: '0.00',
+        discount: String(Number(l.discount ?? 0).toFixed(2)),
         order: i,
         metadata: {},
       }));
@@ -885,8 +894,9 @@ export default function QuoteEditPage() {
             ) : (
               <div className="divide-y divide-border/50">
                 {quote.line_items.map((l, i) => {
-                  const base = l.quantity * l.unit_price;
-                  const tot = base * (1 + (l.tax_rate ?? 0));
+                  const base = l.quantity * l.unit_price - (l.discount ?? 0);
+                  const preTax = Math.max(0, base);
+                  const tot = preTax * (1 + (l.tax_rate ?? 0));
                   return (
                     <div
                       key={i}
@@ -932,8 +942,8 @@ export default function QuoteEditPage() {
                             />
                           </div>
 
-                          {/* Row 3: Quantité, Prix, TVA, Total */}
-                          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 items-end pt-2">
+                          {/* Row 3: Quantité, Prix, Remise, TVA, Total */}
+                          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 items-end pt-2">
                             <div className="space-y-1.5">
                               <Label className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                                 Quantité
@@ -963,6 +973,28 @@ export default function QuoteEditPage() {
                                   onChange={(e) =>
                                     updateLine(i, {
                                       unit_price: Number(e.target.value),
+                                    })
+                                  }
+                                  className="h-9 pr-8"
+                                />
+                                <span className="absolute right-3 top-2.5 text-[10px] text-muted-foreground font-bold">
+                                  €
+                                </span>
+                              </div>
+                            </div>
+                            <div className="space-y-1.5">
+                              <Label className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                Remise
+                              </Label>
+                              <div className="relative">
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step="0.01"
+                                  value={l.discount ?? 0}
+                                  onChange={(e) =>
+                                    updateLine(i, {
+                                      discount: Number(e.target.value),
                                     })
                                   }
                                   className="h-9 pr-8"


### PR DESCRIPTION
## Contexte 

Le champ "REMISE" d'une prestation lors de la création d'un devis n'est pas pris en compte lors du calcule du prix global + n'apparait pas dans la page QuoteDetailPage ni QuoteEditPage.
                                                                                              
Root cause: Frontend missing discount field entirely (types, mappers, UI)                                  

Fixed files:                                                                                               

* frontend/src/domain/quote/types.ts - Added discount to UiQuoteLine & UiQuoteLineDetail          
* frontend/src/domain/quote/mappers.ts - Map discount API↔UI (3 locations)                               
* frontend/src/interface/pages/Quote/QuoteEditPage.tsx - Added discount input field, fixed totals calc, fixed payload                                                                                                
* frontend/src/interface/pages/Quote/QuoteDetailPage.tsx - Display discount column in table, fixed totals 
  calc                                                                                                         
                                                                                                               
Changes:                                                                                                     
  - QuoteEditPage: Added "Remise" column (grid 4→5 cols)                                                       
  - QuoteDetailPage: Added "Remise" column with conditional display                                            
  - Totals now: pre_tax = qty * unit_price - discount (capped at 0)                                            
  - All type checks ✅, linting ✅   